### PR TITLE
Add irrigation analysis with shapefile-based harvest & seeding breakdown

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -10,10 +10,11 @@ import { FieldMap } from '@/components/dashboard/field-map';
 import { FieldsList } from '@/components/dashboard/fields-list';
 import { FieldFilters } from '@/components/dashboard/field-filters';
 import { HarvestOperations } from '@/components/dashboard/harvest-operations';
+import { IrrigationAnalysis } from '@/components/dashboard/irrigation-analysis';
 import { fetchStoredFields, importFieldsWithBoundaries } from '@/lib/john-deere-client';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Loader as Loader2, LogOut, Tractor, Map, MapPin, Wheat, User } from 'lucide-react';
+import { Loader as Loader2, LogOut, Tractor, Map, MapPin, Wheat, Droplets, User } from 'lucide-react';
 import type { StoredField } from '@/types/john-deere';
 
 export default function DashboardPage() {
@@ -167,6 +168,13 @@ export default function DashboardPage() {
                           <Wheat className="w-4 h-4 mr-2" />
                           Harvest Operations
                         </TabsTrigger>
+                        <TabsTrigger
+                          value="irrigation"
+                          className="data-[state=active]:bg-emerald-600 data-[state=active]:text-white"
+                        >
+                          <Droplets className="w-4 h-4 mr-2" />
+                          Irrigation
+                        </TabsTrigger>
                       </TabsList>
 
                       <AreaUnitToggle
@@ -200,6 +208,13 @@ export default function DashboardPage() {
 
                     <TabsContent value="harvest" className="mt-4">
                       <HarvestOperations key={`harvest-${refreshKey}`} />
+                    </TabsContent>
+
+                    <TabsContent value="irrigation" className="mt-4">
+                      <IrrigationAnalysis
+                        fields={storedFields}
+                        preferredUnit={preferredUnit}
+                      />
                     </TabsContent>
                   </Tabs>
                 </>

--- a/components/dashboard/irrigation-analysis.tsx
+++ b/components/dashboard/irrigation-analysis.tsx
@@ -1,0 +1,454 @@
+'use client';
+
+import { useState } from 'react';
+import { fetchIrrigationAnalysis, pollForShapefileUrl, fetchHarvestOperations, fetchSeedingOperations } from '@/lib/john-deere-client';
+import { supabase } from '@/lib/supabase';
+import { processShapefile, classifyHarvestPolygons, classifySeedingPolygons, type HarvestZoneStats, type SeedingZoneStats } from '@/lib/shapefile-analysis';
+import { Button } from '@/components/ui/button';
+import { Loader as Loader2, Droplets, Wheat, Sprout } from 'lucide-react';
+import { PieChart, Pie, Cell, ResponsiveContainer, Legend, Tooltip } from 'recharts';
+import { convertArea } from '@/lib/area-utils';
+import type { StoredField, IrrigationAnalysis as IrrigationAnalysisType } from '@/types/john-deere';
+
+interface Props {
+  fields: StoredField[];
+  preferredUnit: string;
+}
+
+const COLORS = {
+  irrigated: '#10b981',
+  dryland: '#f59e0b',
+};
+
+function formatAcres(acres: number, preferredUnit: string): string {
+  if (preferredUnit === 'ha') {
+    return convertArea(acres, 'ac', 'ha').toLocaleString(undefined, { maximumFractionDigits: 1 }) + ' ha';
+  }
+  return acres.toLocaleString(undefined, { maximumFractionDigits: 1 }) + ' ac';
+}
+
+type OpEntry = { id: string; startDate?: string; crop?: { name: string }; fieldName: string };
+
+// --- Reusable analysis section for a single operation type ---
+
+function OperationSection({
+  title,
+  icon,
+  accentColor,
+  ops,
+  opsLoading,
+  analysis,
+  preferredUnit,
+  onRun,
+}: {
+  title: string;
+  icon: React.ReactNode;
+  accentColor: string;
+  ops: OpEntry[];
+  opsLoading: boolean;
+  analysis: IrrigationAnalysisType | null;
+  preferredUnit: string;
+  onRun: (operationId: string) => Promise<void>;
+}) {
+  const [selectedOpId, setSelectedOpId] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [progressStatus, setProgressStatus] = useState('');
+  const [pollAttempt, setPollAttempt] = useState(0);
+  const [result, setResult] = useState<HarvestZoneStats | SeedingZoneStats | null>(null);
+
+  const handleRun = async () => {
+    if (!selectedOpId || !analysis) return;
+    setIsLoading(true);
+    setError(null);
+    setResult(null);
+    setPollAttempt(0);
+    setProgressStatus('');
+
+    try {
+      setProgressStatus('Waiting for John Deere to generate shapefile...');
+      const storagePath = await pollForShapefileUrl(
+        selectedOpId,
+        (attempt) => setPollAttempt(attempt),
+      );
+
+      setProgressStatus('Downloading shapefile from storage...');
+      const { data: blob, error: downloadError } = await supabase.storage
+        .from('shapefiles')
+        .download(storagePath);
+
+      if (downloadError || !blob) {
+        throw new Error(`Failed to download shapefile: ${downloadError?.message || 'No data'}`);
+      }
+      const zipBuffer = await blob.arrayBuffer();
+
+      setProgressStatus(`Parsing shapefile (${(zipBuffer.byteLength / 1024 / 1024).toFixed(1)} MB)...`);
+      const geojson = await processShapefile(zipBuffer);
+
+      const interiorRings = (analysis.interiorRingsGeoJSON || []) as Array<{ type: 'Polygon'; coordinates: number[][][] }>;
+      setProgressStatus(`Analyzing ${geojson.features.length.toLocaleString()} polygons...`);
+
+      if (title.toLowerCase().includes('seeding') || title.toLowerCase().includes('planting')) {
+        setResult(classifySeedingPolygons(geojson, interiorRings, analysis.irrigated));
+      } else {
+        setResult(classifyHarvestPolygons(geojson, interiorRings, analysis.irrigated));
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Analysis failed');
+    } finally {
+      setIsLoading(false);
+      setProgressStatus('');
+    }
+  };
+
+  const isHarvest = !title.toLowerCase().includes('seeding') && !title.toLowerCase().includes('planting');
+
+  return (
+    <div className="bg-white rounded-xl border border-slate-200 p-6">
+      <h3 className="text-lg font-semibold text-slate-900 mb-4 flex items-center gap-2">
+        {icon}
+        {title}
+      </h3>
+
+      <div className="flex items-end gap-4 flex-wrap">
+        <div className="flex-1 min-w-[200px]">
+          <label className="block text-sm font-medium text-slate-700 mb-1">
+            Select Operation
+          </label>
+          {opsLoading ? (
+            <div className="flex items-center gap-2 text-sm text-slate-500 py-2">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              Loading...
+            </div>
+          ) : ops.length === 0 ? (
+            <p className="text-sm text-slate-500 py-2">No operations found for this field.</p>
+          ) : (
+            <select
+              value={selectedOpId}
+              onChange={(e) => { setSelectedOpId(e.target.value); setResult(null); }}
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500"
+            >
+              <option value="">Choose an operation...</option>
+              {ops.map((op) => (
+                <option key={op.id} value={op.id}>
+                  {op.crop?.name || 'Unknown crop'} — {op.startDate ? new Date(op.startDate).toLocaleDateString() : 'Unknown date'}
+                </option>
+              ))}
+            </select>
+          )}
+        </div>
+
+        <Button
+          onClick={handleRun}
+          disabled={!selectedOpId || isLoading}
+          className={`${accentColor} text-white`}
+        >
+          {isLoading ? (
+            <>
+              <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+              Analyzing...
+            </>
+          ) : (
+            'Run Analysis'
+          )}
+        </Button>
+      </div>
+
+      {isLoading && (
+        <div className="mt-4 p-3 bg-blue-50 border border-blue-200 rounded-lg text-sm text-blue-700">
+          <div className="flex items-center gap-2">
+            <Loader2 className="w-4 h-4 animate-spin" />
+            <span>{progressStatus || 'Starting...'}</span>
+          </div>
+          {pollAttempt > 1 && (
+            <p className="mt-1 text-xs text-blue-600">
+              Poll attempt {pollAttempt} — large operations can take a minute or two.
+            </p>
+          )}
+        </div>
+      )}
+
+      {error && (
+        <div className="mt-4 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      {result && isHarvest && (() => {
+        const r = result as HarvestZoneStats;
+        const pieData = [
+          { name: 'Irrigated', value: r.irrigatedHarvestedAcres, color: COLORS.irrigated },
+          { name: 'Dryland', value: r.drylandHarvestedAcres, color: COLORS.dryland },
+        ].filter(d => d.value > 0);
+
+        return (
+          <div className="mt-6 grid grid-cols-1 md:grid-cols-2 gap-6">
+            {pieData.length > 0 && (
+              <div className="h-56">
+                <ResponsiveContainer width="100%" height="100%">
+                  <PieChart>
+                    <Pie data={pieData} cx="50%" cy="50%" innerRadius={40} outerRadius={75} paddingAngle={2} dataKey="value"
+                      label={({ value }) => formatAcres(value, preferredUnit)}>
+                      {pieData.map((entry, i) => <Cell key={i} fill={entry.color} />)}
+                    </Pie>
+                    <Tooltip formatter={(value: number) => formatAcres(value, preferredUnit)} />
+                    <Legend />
+                  </PieChart>
+                </ResponsiveContainer>
+              </div>
+            )}
+            <div className="space-y-3">
+              <div className="grid grid-cols-2 gap-3">
+                <div className="bg-emerald-50 rounded-lg p-3">
+                  <p className="text-xs text-emerald-700 font-medium">Irrigated Harvested</p>
+                  <p className="text-lg font-bold text-emerald-900">{formatAcres(r.irrigatedHarvestedAcres, preferredUnit)}</p>
+                  {r.irrigatedAvgYield != null && <p className="text-xs text-emerald-600">Avg yield: {r.irrigatedAvgYield.toLocaleString(undefined, { maximumFractionDigits: 1 })}</p>}
+                  {r.irrigatedAvgMoisture != null && <p className="text-xs text-emerald-600">Avg moisture: {r.irrigatedAvgMoisture.toFixed(1)}%</p>}
+                </div>
+                <div className="bg-amber-50 rounded-lg p-3">
+                  <p className="text-xs text-amber-700 font-medium">Dryland Harvested</p>
+                  <p className="text-lg font-bold text-amber-900">{formatAcres(r.drylandHarvestedAcres, preferredUnit)}</p>
+                  {r.drylandAvgYield != null && <p className="text-xs text-amber-600">Avg yield: {r.drylandAvgYield.toLocaleString(undefined, { maximumFractionDigits: 1 })}</p>}
+                  {r.drylandAvgMoisture != null && <p className="text-xs text-amber-600">Avg moisture: {r.drylandAvgMoisture.toFixed(1)}%</p>}
+                </div>
+              </div>
+              <p className="text-xs text-slate-500">Analyzed {r.harvestPolygonCount.toLocaleString()} harvest polygons</p>
+            </div>
+          </div>
+        );
+      })()}
+
+      {result && !isHarvest && (() => {
+        const r = result as SeedingZoneStats;
+        const pieData = [
+          { name: 'Irrigated', value: r.irrigatedSeededAcres, color: COLORS.irrigated },
+          { name: 'Dryland', value: r.drylandSeededAcres, color: COLORS.dryland },
+        ].filter(d => d.value > 0);
+
+        return (
+          <div className="mt-6 grid grid-cols-1 md:grid-cols-2 gap-6">
+            {pieData.length > 0 && (
+              <div className="h-56">
+                <ResponsiveContainer width="100%" height="100%">
+                  <PieChart>
+                    <Pie data={pieData} cx="50%" cy="50%" innerRadius={40} outerRadius={75} paddingAngle={2} dataKey="value"
+                      label={({ value }) => formatAcres(value, preferredUnit)}>
+                      {pieData.map((entry, i) => <Cell key={i} fill={entry.color} />)}
+                    </Pie>
+                    <Tooltip formatter={(value: number) => formatAcres(value, preferredUnit)} />
+                    <Legend />
+                  </PieChart>
+                </ResponsiveContainer>
+              </div>
+            )}
+            <div className="space-y-3">
+              <div className="grid grid-cols-2 gap-3">
+                <div className="bg-emerald-50 rounded-lg p-3">
+                  <p className="text-xs text-emerald-700 font-medium">Irrigated Seeded</p>
+                  <p className="text-lg font-bold text-emerald-900">{formatAcres(r.irrigatedSeededAcres, preferredUnit)}</p>
+                  {r.irrigatedAvgSeedingRate != null && <p className="text-xs text-emerald-600">Avg rate: {r.irrigatedAvgSeedingRate.toLocaleString(undefined, { maximumFractionDigits: 0 })}</p>}
+                  {r.irrigatedAvgControlRate != null && <p className="text-xs text-emerald-600">Rx rate: {r.irrigatedAvgControlRate.toLocaleString(undefined, { maximumFractionDigits: 0 })}</p>}
+                </div>
+                <div className="bg-amber-50 rounded-lg p-3">
+                  <p className="text-xs text-amber-700 font-medium">Dryland Seeded</p>
+                  <p className="text-lg font-bold text-amber-900">{formatAcres(r.drylandSeededAcres, preferredUnit)}</p>
+                  {r.drylandAvgSeedingRate != null && <p className="text-xs text-amber-600">Avg rate: {r.drylandAvgSeedingRate.toLocaleString(undefined, { maximumFractionDigits: 0 })}</p>}
+                  {r.drylandAvgControlRate != null && <p className="text-xs text-amber-600">Rx rate: {r.drylandAvgControlRate.toLocaleString(undefined, { maximumFractionDigits: 0 })}</p>}
+                </div>
+              </div>
+              <p className="text-xs text-slate-500">Analyzed {r.seedingPolygonCount.toLocaleString()} seeding polygons</p>
+            </div>
+          </div>
+        );
+      })()}
+    </div>
+  );
+}
+
+// --- Main component ---
+
+export function IrrigationAnalysis({ fields, preferredUnit }: Props) {
+  const [selectedFieldId, setSelectedFieldId] = useState<string>('');
+  const [analysis, setAnalysis] = useState<IrrigationAnalysisType | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [harvestOps, setHarvestOps] = useState<OpEntry[]>([]);
+  const [seedingOps, setSeedingOps] = useState<OpEntry[]>([]);
+  const [opsLoading, setOpsLoading] = useState(false);
+
+  const fieldsWithBoundary = fields.filter(f => f.active_boundary && f.boundary_geojson);
+
+  const handleAnalyze = async () => {
+    if (!selectedFieldId) return;
+    setIsLoading(true);
+    setError(null);
+    setAnalysis(null);
+    setHarvestOps([]);
+    setSeedingOps([]);
+
+    try {
+      const result = await fetchIrrigationAnalysis(selectedFieldId);
+      setAnalysis(result);
+
+      setOpsLoading(true);
+      try {
+        const [harvestData, seedingData] = await Promise.all([
+          fetchHarvestOperations().catch(() => ({ values: [] })),
+          fetchSeedingOperations().catch(() => ({ values: [] })),
+        ]);
+
+        const flattenOps = (data: { values?: Array<{ fieldId: string; fieldName: string; operations: Array<{ id: string; startDate?: string; crop?: { name: string } }> }> }) =>
+          (data.values || [])
+            .filter((fo) => fo.fieldId === selectedFieldId)
+            .flatMap((fo) => fo.operations.map((op) => ({ ...op, fieldName: fo.fieldName })));
+
+        setHarvestOps(flattenOps(harvestData));
+        setSeedingOps(flattenOps(seedingData));
+      } catch (_) {
+        // Non-critical
+      } finally {
+        setOpsLoading(false);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to analyze irrigation');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const pieData = analysis ? [
+    { name: 'Irrigated', value: analysis.irrigatedAcres, color: COLORS.irrigated },
+    { name: 'Dryland', value: analysis.drylandAcres, color: COLORS.dryland },
+  ].filter(d => d.value > 0) : [];
+
+  return (
+    <div className="space-y-6">
+      {/* Field Selector */}
+      <div className="bg-white rounded-xl border border-slate-200 p-6">
+        <h3 className="text-lg font-semibold text-slate-900 mb-4 flex items-center gap-2">
+          <Droplets className="w-5 h-5 text-emerald-600" />
+          Irrigation Analysis
+        </h3>
+
+        <div className="flex items-end gap-4 flex-wrap">
+          <div className="flex-1 min-w-[200px]">
+            <label className="block text-sm font-medium text-slate-700 mb-1">Select Field</label>
+            <select
+              value={selectedFieldId}
+              onChange={(e) => { setSelectedFieldId(e.target.value); setAnalysis(null); }}
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500"
+            >
+              <option value="">Choose a field...</option>
+              {fieldsWithBoundary.map((field) => (
+                <option key={field.jd_field_id} value={field.jd_field_id}>
+                  {field.name} {field.farm_name ? `(${field.farm_name})` : ''}
+                </option>
+              ))}
+            </select>
+          </div>
+          <Button onClick={handleAnalyze} disabled={!selectedFieldId || isLoading} className="bg-emerald-600 hover:bg-emerald-700 text-white">
+            {isLoading ? <><Loader2 className="w-4 h-4 mr-2 animate-spin" />Analyzing...</> : 'Analyze Boundary'}
+          </Button>
+        </div>
+
+        {error && <div className="mt-4 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">{error}</div>}
+      </div>
+
+      {/* Boundary Analysis Results */}
+      {analysis && (
+        <div className="bg-white rounded-xl border border-slate-200 p-6">
+          <div className="flex items-center justify-between mb-4">
+            <h3 className="text-lg font-semibold text-slate-900">{analysis.fieldName}</h3>
+            <span className={`px-3 py-1 rounded-full text-xs font-medium ${analysis.irrigated ? 'bg-emerald-100 text-emerald-700' : 'bg-amber-100 text-amber-700'}`}>
+              {analysis.irrigated ? 'Irrigated' : 'Dryland'}
+            </span>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            {pieData.length > 0 && (
+              <div className="h-64">
+                <ResponsiveContainer width="100%" height="100%">
+                  <PieChart>
+                    <Pie data={pieData} cx="50%" cy="50%" innerRadius={50} outerRadius={90} paddingAngle={2} dataKey="value"
+                      label={({ name, value }) => `${name}: ${formatAcres(value, preferredUnit)}`}>
+                      {pieData.map((entry, i) => <Cell key={i} fill={entry.color} />)}
+                    </Pie>
+                    <Tooltip formatter={(value: number) => formatAcres(value, preferredUnit)} />
+                    <Legend />
+                  </PieChart>
+                </ResponsiveContainer>
+              </div>
+            )}
+            <div className="space-y-4">
+              <div className="grid grid-cols-2 gap-4">
+                <div className="bg-emerald-50 rounded-lg p-4">
+                  <p className="text-sm text-emerald-700 font-medium">Irrigated</p>
+                  <p className="text-2xl font-bold text-emerald-900">{formatAcres(analysis.irrigatedAcres, preferredUnit)}</p>
+                  {(analysis.irrigatedAcres + analysis.drylandAcres) > 0 && (
+                    <p className="text-xs text-emerald-600 mt-1">{((analysis.irrigatedAcres / (analysis.irrigatedAcres + analysis.drylandAcres)) * 100).toFixed(1)}%</p>
+                  )}
+                </div>
+                <div className="bg-amber-50 rounded-lg p-4">
+                  <p className="text-sm text-amber-700 font-medium">Dryland</p>
+                  <p className="text-2xl font-bold text-amber-900">{formatAcres(analysis.drylandAcres, preferredUnit)}</p>
+                  {(analysis.irrigatedAcres + analysis.drylandAcres) > 0 && (
+                    <p className="text-xs text-amber-600 mt-1">{((analysis.drylandAcres / (analysis.irrigatedAcres + analysis.drylandAcres)) * 100).toFixed(1)}%</p>
+                  )}
+                </div>
+              </div>
+              <div className="bg-slate-50 rounded-lg p-4">
+                <p className="text-sm text-slate-600 font-medium">Total Field Area</p>
+                <p className="text-xl font-bold text-slate-900">{formatAcres(analysis.irrigatedAcres + analysis.drylandAcres, preferredUnit)}</p>
+                {analysis.totalArea && (
+                  <p className="text-xs text-slate-500 mt-1">
+                    JD reported: {analysis.totalArea.value.toLocaleString(undefined, { maximumFractionDigits: 1 })} {analysis.totalArea.unit}
+                    {analysis.workableArea && ` | Workable: ${analysis.workableArea.value.toLocaleString(undefined, { maximumFractionDigits: 1 })} ${analysis.workableArea.unit}`}
+                  </p>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Side-by-side Seeding + Harvest Analysis */}
+      {analysis && (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <OperationSection
+            title="Seeding / Planting"
+            icon={<Sprout className="w-5 h-5 text-green-600" />}
+            accentColor="bg-green-600 hover:bg-green-700"
+            ops={seedingOps}
+            opsLoading={opsLoading}
+            analysis={analysis}
+            preferredUnit={preferredUnit}
+            onRun={async () => {}}
+          />
+          <OperationSection
+            title="Harvest"
+            icon={<Wheat className="w-5 h-5 text-amber-600" />}
+            accentColor="bg-amber-600 hover:bg-amber-700"
+            ops={harvestOps}
+            opsLoading={opsLoading}
+            analysis={analysis}
+            preferredUnit={preferredUnit}
+            onRun={async () => {}}
+          />
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!analysis && !isLoading && (
+        <div className="bg-white rounded-xl border border-slate-200 p-12 text-center">
+          <Droplets className="w-12 h-12 text-slate-300 mx-auto mb-4" />
+          <h3 className="text-lg font-medium text-slate-600 mb-2">Irrigation Analysis</h3>
+          <p className="text-sm text-slate-500 max-w-md mx-auto">
+            Select a field with an active boundary to analyze irrigated vs dryland acres.
+            The analysis uses field boundary data from John Deere Operations Center.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/area-utils.ts
+++ b/lib/area-utils.ts
@@ -1,5 +1,18 @@
 const HA_TO_AC = 2.47105;
 const AC_TO_HA = 1 / HA_TO_AC;
+const SQM_TO_AC = 0.000247105;
+const SQM_TO_HA = 0.0001;
+
+export function sqMetersToAcres(sqm: number): number {
+  return sqm * SQM_TO_AC;
+}
+
+export function sqMetersToUnit(sqm: number, unit: string): number {
+  const u = unit.toLowerCase();
+  if (u === 'ac') return sqm * SQM_TO_AC;
+  if (u === 'ha') return sqm * SQM_TO_HA;
+  return sqm;
+}
 
 export function convertArea(
   value: number,

--- a/lib/john-deere-client.ts
+++ b/lib/john-deere-client.ts
@@ -134,6 +134,20 @@ export async function fetchHarvestOperations() {
   return response.json();
 }
 
+export async function fetchSeedingOperations() {
+  const headers = await getAuthHeaders();
+  const response = await fetch(`${SUPABASE_URL}/functions/v1/john-deere-api?action=seeding-operations`, {
+    headers,
+  });
+
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(error.error || 'Failed to fetch seeding operations');
+  }
+
+  return response.json();
+}
+
 export async function importFieldsWithBoundaries() {
   const headers = await getAuthHeaders();
   const response = await fetch(`${SUPABASE_URL}/functions/v1/john-deere-api?action=import-fields`, {
@@ -161,6 +175,58 @@ export async function fetchStoredFields() {
   }
 
   return response.json();
+}
+
+export async function fetchIrrigationAnalysis(fieldId: string) {
+  const headers = await getAuthHeaders();
+  const response = await fetch(
+    `${SUPABASE_URL}/functions/v1/john-deere-irrigation?action=irrigation-analysis&fieldId=${encodeURIComponent(fieldId)}`,
+    { headers },
+  );
+
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(error.error || 'Failed to fetch irrigation analysis');
+  }
+
+  return response.json();
+}
+
+export async function pollForShapefileUrl(
+  operationId: string,
+  onProgress?: (attempt: number, status: string) => void,
+): Promise<string> {
+  const headers = await getAuthHeaders();
+  const maxAttempts = 40;
+  const pollIntervalMs = 5000;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    onProgress?.(attempt, 'polling');
+
+    const response = await fetch(
+      `${SUPABASE_URL}/functions/v1/john-deere-irrigation?action=shapefile-status&operationId=${encodeURIComponent(operationId)}`,
+      { headers },
+    );
+
+    if (response.status === 202) {
+      await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+      continue;
+    }
+
+    if (!response.ok) {
+      const error = await response.json();
+      throw new Error(error.error || 'Failed to check shapefile status');
+    }
+
+    const data = await response.json();
+    if (data.status === 'ready' && data.storagePath) {
+      return data.storagePath as string;
+    }
+
+    throw new Error('Unexpected shapefile status response');
+  }
+
+  throw new Error('Shapefile processing timed out. Try again in a few minutes.');
 }
 
 export function getJohnDeereAuthUrl(redirectUri: string, state: string) {

--- a/lib/shapefile-analysis.ts
+++ b/lib/shapefile-analysis.ts
@@ -1,0 +1,208 @@
+import shp from 'shpjs';
+import * as turf from '@turf/turf';
+import type { Feature, Polygon, MultiPolygon, FeatureCollection, GeoJsonProperties } from 'geojson';
+
+const SQM_TO_AC = 0.000247105;
+
+export interface HarvestZoneStats {
+  irrigatedHarvestedAcres: number;
+  drylandHarvestedAcres: number;
+  irrigatedAvgYield: number | null;
+  drylandAvgYield: number | null;
+  irrigatedAvgMoisture: number | null;
+  drylandAvgMoisture: number | null;
+  harvestPolygonCount: number;
+}
+
+/**
+ * Parse a shapefile zip buffer into a GeoJSON FeatureCollection.
+ */
+export async function processShapefile(
+  zipBuffer: ArrayBuffer,
+): Promise<FeatureCollection> {
+  const result = await shp(zipBuffer);
+
+  // shpjs can return a single FeatureCollection or an array of them
+  if (Array.isArray(result)) {
+    return result[0] as FeatureCollection;
+  }
+  return result as FeatureCollection;
+}
+
+/**
+ * Classify harvest polygons as irrigated or dryland based on whether
+ * they intersect with interior ring polygons (which represent the pivot/irrigated area).
+ */
+export function classifyHarvestPolygons(
+  harvestGeoJSON: FeatureCollection,
+  interiorRingsGeoJSON: Array<{ type: 'Polygon'; coordinates: number[][][] }>,
+  irrigated: boolean,
+): HarvestZoneStats {
+  if (!harvestGeoJSON?.features) {
+    return {
+      irrigatedHarvestedAcres: 0,
+      drylandHarvestedAcres: 0,
+      irrigatedAvgYield: null,
+      drylandAvgYield: null,
+      irrigatedAvgMoisture: null,
+      drylandAvgMoisture: null,
+      harvestPolygonCount: 0,
+    };
+  }
+
+  let irrigatedArea = 0;
+  let drylandArea = 0;
+  const irrigatedYields: number[] = [];
+  const drylandYields: number[] = [];
+  const irrigatedMoistures: number[] = [];
+  const drylandMoistures: number[] = [];
+
+  const interiorFeatures = interiorRingsGeoJSON.map(
+    (ring) => turf.feature(ring) as Feature<Polygon>,
+  );
+
+  for (const feature of harvestGeoJSON.features) {
+    if (!feature.geometry) continue;
+
+    const featureSqm = turf.area(feature);
+    const featureAc = featureSqm * SQM_TO_AC;
+
+    const props = feature.properties || {};
+    const yieldVal = props.VRYieldVol ?? props.VrYieldMas ?? props.GrossYldA;
+    const moistureVal = props.Moisture;
+
+    let isIrrigatedPolygon = false;
+
+    if (interiorFeatures.length > 0) {
+      for (const interiorFeature of interiorFeatures) {
+        try {
+          if (turf.booleanIntersects(feature as Feature<Polygon | MultiPolygon>, interiorFeature)) {
+            isIrrigatedPolygon = true;
+            break;
+          }
+        } catch {
+          // Skip invalid geometries
+        }
+      }
+    } else if (irrigated) {
+      isIrrigatedPolygon = true;
+    }
+
+    if (isIrrigatedPolygon) {
+      irrigatedArea += featureAc;
+      if (typeof yieldVal === 'number') irrigatedYields.push(yieldVal);
+      if (typeof moistureVal === 'number') irrigatedMoistures.push(moistureVal);
+    } else {
+      drylandArea += featureAc;
+      if (typeof yieldVal === 'number') drylandYields.push(yieldVal);
+      if (typeof moistureVal === 'number') drylandMoistures.push(moistureVal);
+    }
+  }
+
+  const avg = (arr: number[]) =>
+    arr.length > 0 ? arr.reduce((a, b) => a + b, 0) / arr.length : null;
+
+  return {
+    irrigatedHarvestedAcres: irrigatedArea,
+    drylandHarvestedAcres: drylandArea,
+    irrigatedAvgYield: avg(irrigatedYields),
+    drylandAvgYield: avg(drylandYields),
+    irrigatedAvgMoisture: avg(irrigatedMoistures),
+    drylandAvgMoisture: avg(drylandMoistures),
+    harvestPolygonCount: harvestGeoJSON.features.length,
+  };
+}
+
+export interface SeedingZoneStats {
+  irrigatedSeededAcres: number;
+  drylandSeededAcres: number;
+  irrigatedAvgSeedingRate: number | null;
+  drylandAvgSeedingRate: number | null;
+  irrigatedAvgControlRate: number | null;
+  drylandAvgControlRate: number | null;
+  seedingPolygonCount: number;
+}
+
+/**
+ * Classify seeding polygons as irrigated or dryland based on whether
+ * they intersect with interior ring polygons (pivot/irrigated area).
+ */
+export function classifySeedingPolygons(
+  seedingGeoJSON: FeatureCollection,
+  interiorRingsGeoJSON: Array<{ type: 'Polygon'; coordinates: number[][][] }>,
+  irrigated: boolean,
+): SeedingZoneStats {
+  if (!seedingGeoJSON?.features) {
+    return {
+      irrigatedSeededAcres: 0,
+      drylandSeededAcres: 0,
+      irrigatedAvgSeedingRate: null,
+      drylandAvgSeedingRate: null,
+      irrigatedAvgControlRate: null,
+      drylandAvgControlRate: null,
+      seedingPolygonCount: 0,
+    };
+  }
+
+  let irrigatedArea = 0;
+  let drylandArea = 0;
+  const irrigatedRates: number[] = [];
+  const drylandRates: number[] = [];
+  const irrigatedControlRates: number[] = [];
+  const drylandControlRates: number[] = [];
+
+  const interiorFeatures = interiorRingsGeoJSON.map(
+    (ring) => turf.feature(ring) as Feature<Polygon>,
+  );
+
+  for (const feature of seedingGeoJSON.features) {
+    if (!feature.geometry) continue;
+
+    const featureSqm = turf.area(feature);
+    const featureAc = featureSqm * SQM_TO_AC;
+
+    const props = feature.properties || {};
+    const appliedRate = props.AppliedRate;
+    const controlRate = props.ControlRate ?? props.TargetRate;
+
+    let isIrrigatedPolygon = false;
+
+    if (interiorFeatures.length > 0) {
+      for (const interiorFeature of interiorFeatures) {
+        try {
+          if (turf.booleanIntersects(feature as Feature<Polygon | MultiPolygon>, interiorFeature)) {
+            isIrrigatedPolygon = true;
+            break;
+          }
+        } catch {
+          // Skip invalid geometries
+        }
+      }
+    } else if (irrigated) {
+      isIrrigatedPolygon = true;
+    }
+
+    if (isIrrigatedPolygon) {
+      irrigatedArea += featureAc;
+      if (typeof appliedRate === 'number') irrigatedRates.push(appliedRate);
+      if (typeof controlRate === 'number') irrigatedControlRates.push(controlRate);
+    } else {
+      drylandArea += featureAc;
+      if (typeof appliedRate === 'number') drylandRates.push(appliedRate);
+      if (typeof controlRate === 'number') drylandControlRates.push(controlRate);
+    }
+  }
+
+  const avg = (arr: number[]) =>
+    arr.length > 0 ? arr.reduce((a, b) => a + b, 0) / arr.length : null;
+
+  return {
+    irrigatedSeededAcres: irrigatedArea,
+    drylandSeededAcres: drylandArea,
+    irrigatedAvgSeedingRate: avg(irrigatedRates),
+    drylandAvgSeedingRate: avg(drylandRates),
+    irrigatedAvgControlRate: avg(irrigatedControlRates),
+    drylandAvgControlRate: avg(drylandControlRates),
+    seedingPolygonCount: seedingGeoJSON.features.length,
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@radix-ui/react-toggle-group": "^1.1.0",
         "@radix-ui/react-tooltip": "^1.1.2",
         "@supabase/supabase-js": "^2.58.0",
+        "@turf/turf": "^7.3.4",
         "@types/node": "20.6.2",
         "@types/react": "18.2.22",
         "@types/react-dom": "18.2.7",
@@ -62,6 +63,7 @@
         "react-hook-form": "^7.53.0",
         "react-resizable-panels": "^2.1.3",
         "recharts": "^2.12.7",
+        "shpjs": "^6.2.0",
         "sonner": "^1.5.0",
         "tailwind-merge": "^2.5.2",
         "tailwindcss": "3.3.3",
@@ -69,6 +71,9 @@
         "typescript": "5.2.2",
         "vaul": "^0.9.9",
         "zod": "^3.23.8"
+      },
+      "devDependencies": {
+        "@types/shpjs": "^3.4.7"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1975,6 +1980,2053 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@turf/along": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/along/-/along-7.3.4.tgz",
+      "integrity": "sha512-PvIoXin0I1t3nRwJz7uqR6fsxDMqdGwJq90qGOeqkNwlZqlF+5o2wKHPwYwi0RXZhLvxRP5qlbNIvV8ADdbWxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bearing": "7.3.4",
+        "@turf/destination": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/angle": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/angle/-/angle-7.3.4.tgz",
+      "integrity": "sha512-235JAfbrNMjHQXQfd/p+fYnlfCHsQsKHda5Eeyc+/jIY0s5mKvhcxgFaOEnigA2q1n+PrVOExs3BViGTKnWhAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bearing": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/rhumb-bearing": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/area": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/area/-/area-7.3.4.tgz",
+      "integrity": "sha512-UEQQFw2XwHpozSBAMEtZI3jDsAad4NnHL/poF7/S6zeDCjEBCkt3MYd6DSGH/cvgcOozxH/ky3/rIVSMZdx4vA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bbox": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-7.3.4.tgz",
+      "integrity": "sha512-D5ErVWtfQbEPh11yzI69uxqrcJmbPU/9Y59f1uTapgwAwQHQztDWgsYpnL3ns8r1GmPWLP8sGJLVTIk2TZSiYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bbox-clip": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-clip/-/bbox-clip-7.3.4.tgz",
+      "integrity": "sha512-HCn0q/WPVEE9Dztg7tCvClOPrrh9MoxNUk73byHvcZLBcvziN6F84f/ZbFcbQSh8hgOeVMs/keeqWMqsICcNLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bbox-polygon": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-7.3.4.tgz",
+      "integrity": "sha512-XCDYQwCA41Bum3R1xX0Na1nR4ozoe/pCYy5bxqrzyMs87kPJUIfBrD5IWxjnZyLqFpfEpolMHJz5ed1uA2PanQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bearing": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-7.3.4.tgz",
+      "integrity": "sha512-zvFjapyFaOrM8nBtAND7f4yb0BJV0jyj6cyoXyTYqLY+3Hn0eHgL0M8lwxDLbTom5KfqYDHDVDQC3+VSfypoEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bezier-spline": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/bezier-spline/-/bezier-spline-7.3.4.tgz",
+      "integrity": "sha512-+iDUeiBKByIs/6K5WW8pG6IDxrRLJHFLM80zSpzk2xBtgy3mq36NZwwt67Pu7EJAkc9GUXKIm9SkspoKue9aYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-clockwise": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-7.3.4.tgz",
+      "integrity": "sha512-X/O+u/OsoJ99mujhlqviuB7HX0tdJ5931TBjNSseps43XtROVuB5PwBDgwKfu5lY1B4DSGAxbbxJ795RmPnguQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-concave": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-concave/-/boolean-concave-7.3.4.tgz",
+      "integrity": "sha512-SHuAzjqaAes6ELDZcN/FKZWCQZsqwYv3gMosoLRFWTwKyBQe8i29e4y6XnXakDr1uklVUeRRcdhZ5oKtX9ABPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-contains": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-7.3.4.tgz",
+      "integrity": "sha512-AJMGbtC6HiXgHvq0RNlTfsDB58Qf9Js45MP/APbhGTH4AiLZ8VMDISywVFNd7qN6oppNlDd3xApVR28+ti8bNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/boolean-point-on-line": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/line-split": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-crosses": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-crosses/-/boolean-crosses-7.3.4.tgz",
+      "integrity": "sha512-v/U3SuGdkexfLTMhho6Vj0OjqPUeYdThxp8zggGJ1VHow27fvLLez0DjUR3AftHjjHM6bRzZoNsu2qUlEe5hjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-equal": "7.3.4",
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/line-intersect": "7.3.4",
+        "@turf/polygon-to-line": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-disjoint": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-disjoint/-/boolean-disjoint-7.3.4.tgz",
+      "integrity": "sha512-Dl4O27ygi2NqskGQuvSlDLJYlJ2SPkHb3A9T/v6eAudjlMiKdEY6bMxKUfU5y+Px1WiCZxd+9rXGXJgGC3WiQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/line-intersect": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/polygon-to-line": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-equal": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-equal/-/boolean-equal-7.3.4.tgz",
+      "integrity": "sha512-AhWqe7D1o0wp3d3QQRSqgWDI8s1JfTFKFe9rU5mrSxYPGlmaQsJC07RCaYfFiGym9lACd1lxBJiPidCbLaPOfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clean-coords": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "geojson-equality-ts": "^1.0.2",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-intersects": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-intersects/-/boolean-intersects-7.3.4.tgz",
+      "integrity": "sha512-sxi41NXkb5hrJgOvpm32hyBLhW8fem0vn2XxR4+jyRg1rM/v3ziF10/VqC9KDZuDNZkt9JjL9B0825Cf7AN6Lg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-disjoint": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-overlap": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-overlap/-/boolean-overlap-7.3.4.tgz",
+      "integrity": "sha512-Q3dlswIuqffSiMfln7xa36YDnN1TWtERMF/155rzjglm4NTUG/6S+gNsb8s6qpLjc+hN6btCq1ZjxAWurPf8Vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/line-intersect": "7.3.4",
+        "@turf/line-overlap": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "geojson-equality-ts": "^1.0.2",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-parallel": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-parallel/-/boolean-parallel-7.3.4.tgz",
+      "integrity": "sha512-sTNMqsUkLPnSJEqc2IZ5ig3nHRoubyOH2HW1LILqOybCJI630FEM9UoYP1pZniF5nwTyCjQWnXA1FxusVILuFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clean-coords": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/line-segment": "7.3.4",
+        "@turf/rhumb-bearing": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-point-in-polygon": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-7.3.4.tgz",
+      "integrity": "sha512-v/4hfyY90Vz9cDgs2GwjQf+Lft8o7mNCLJOTz/iv8SHAIgMMX0czEoIaNVOJr7tBqPqwin1CGwsncrkf5C9n8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "point-in-polygon-hao": "^1.1.0",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-point-on-line": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-7.3.4.tgz",
+      "integrity": "sha512-70gm5x6YQOZKcw0b/O4jjMwVWnFj+Zb6TXozLgZFDZShc8pgTQtZku7K+HKZ7Eya+7usHIB4IimZauomOMa+iw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-touches": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-touches/-/boolean-touches-7.3.4.tgz",
+      "integrity": "sha512-XOwhjc0oCWhnBUB+l4drpXcg7mkNXPX3SuSz/Xv7gvLH/yRrBwzVGllzK1AHlGU9BVkGVBJIZGYX7jgTM681NQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/boolean-point-on-line": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-valid": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-valid/-/boolean-valid-7.3.4.tgz",
+      "integrity": "sha512-P6M9BtRvzFF2N5g+1/DTIbYGpEbwQ2sv/Pw+uj11P3NYAA9VE8mvrxFYf+CowFdSfY6bY4ejhuqKhrTmAMv7wA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/boolean-crosses": "7.3.4",
+        "@turf/boolean-disjoint": "7.3.4",
+        "@turf/boolean-overlap": "7.3.4",
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/boolean-point-on-line": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/line-intersect": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "geojson-polygon-self-intersections": "^1.2.1",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-within": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-within/-/boolean-within-7.3.4.tgz",
+      "integrity": "sha512-eLgi803gz0KcYkyxnnqnz9Vd6tw2/0eAExe/Rq8sO0dqypaSiomSumxjqu89d/yo24Qz8gW7c0kJ6YihNbMYxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/boolean-point-on-line": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/line-split": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/buffer": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-7.3.4.tgz",
+      "integrity": "sha512-MVOCBDuOl3KGDsh2stW12RmiFaFeSkVjeUbZ+ADUtIVnv+jlFsmjBpFtsEw8s9YQn5g0667QppOshm0FBHA57Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/center": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/jsts": "^2.7.1",
+        "@turf/meta": "7.3.4",
+        "@turf/projection": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "d3-geo": "1.7.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/center": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/center/-/center-7.3.4.tgz",
+      "integrity": "sha512-4SsLMDHWthXbyIHsczgFCo4fx+8tC8w2+B5HdEuY+P+cSOOL4T+6QQzd7WWjuN/Y3ndowFssUmwRrvXuwVRxQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/center-mean": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/center-mean/-/center-mean-7.3.4.tgz",
+      "integrity": "sha512-6foVk5HLjlSPr48EI686Eis6/bYrJiHjKQlwY/7YlJc1uDitsIjPw2LjUCGIUZDEd6PdNUgg1+LgI7klXYvW3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/center-median": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/center-median/-/center-median-7.3.4.tgz",
+      "integrity": "sha512-Bz6rDr0plQOGSXgT3X3t941pYd44a5vIY8OEt4Y11H1BsgpmzFc6g7L5mr7FXW/uiYGxOewAfNcVUYUdJf9kMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/center-mean": "7.3.4",
+        "@turf/centroid": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/center-of-mass": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/center-of-mass/-/center-of-mass-7.3.4.tgz",
+      "integrity": "sha512-mOSupDF5qxQTA/kOWYletHcBJQ3S2gVl/IRgrBH/YY9yiFq6UGRpZ0sNcIML4H06u/1DY/jqqG+d1nc/1yIA6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/centroid": "7.3.4",
+        "@turf/convex": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/centroid": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-7.3.4.tgz",
+      "integrity": "sha512-6c3kyTSKBrmiPMe75UkHw6MgedroZ6eR5usEvdlDhXgA3MudFPXIZkMFmMd1h9XeJ9xFfkmq+HPCdF0cOzvztA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/circle": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-7.3.4.tgz",
+      "integrity": "sha512-6ccr5iT51/XONF+pbpkqoRxKX4ZVWLubXb1frGCnClv2suo1UIY9SIlINNctVDupXd2P9PpqZCbrXATrcrokPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/destination": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clean-coords": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/clean-coords/-/clean-coords-7.3.4.tgz",
+      "integrity": "sha512-S61aJXLvPN/uZHtjzmJbLv7xhi28Sq3PshCIZSvno4Mo45bvl79Vg4aZskrG05AaSSbipplqfH+MZrkW9Xboeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-on-line": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clone": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-7.3.4.tgz",
+      "integrity": "sha512-pwQ+RyQw986uu7IulY/18NRAebwZZScb084bvVqVkTrllwLSv4oVBqUxmUMiwtp+PNdiRGRFOvNyZqtRsiD+Jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clusters": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/clusters/-/clusters-7.3.4.tgz",
+      "integrity": "sha512-+zoSyiF0LilXy4Tr0/lC7IgqbTMZZ2wwP3iSrqre58b61pUtdhCnBcjA2r8FkcW7z3GMbGf5XkIWhO+b+vDSsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clusters-dbscan": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/clusters-dbscan/-/clusters-dbscan-7.3.4.tgz",
+      "integrity": "sha512-RkuXf767Shk0AfY+fh0PASVw8YR4H8zYR7XQrCgWd/bCuh6CXs7rWZ6UTLu/PiA6y6WsIhyAQv4LhNH5kCzpbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "@types/geokdbush": "^1.1.5",
+        "geokdbush": "^2.0.1",
+        "kdbush": "^4.0.2",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clusters-kmeans": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/clusters-kmeans/-/clusters-kmeans-7.3.4.tgz",
+      "integrity": "sha512-89mlwhcb+vyZAKX0eBa3LQ8VyIKLayrzJpKGb90sEkIu0hDua9JCE+zlbaPoUAvAqflEiX+poFFuh7pngtsBMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "skmeans": "0.9.7",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/collect": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/collect/-/collect-7.3.4.tgz",
+      "integrity": "sha512-fG28oDZK4HCXC/AhF0pmHKLtI9DWwdJr/ktuWolrqzA5b1G7eawrXwDu8B5I3sXhdWonNRMcuLbIuz+XQscHKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "rbush": "^3.0.1",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/combine": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/combine/-/combine-7.3.4.tgz",
+      "integrity": "sha512-wNp9ar4FfpTfQXLZWXQ/jUBBoUFOwRN/mmlv5xrhoYFpP/F5SNy7GVDMZXaBfHdUUplfJUPF5hIKQlCUR8+k3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/concave": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/concave/-/concave-7.3.4.tgz",
+      "integrity": "sha512-HZa1CV2pv4Xpcoe3t5S3ZW6j9jVbc27exzKwZWF7MlFxSz4BKRirWiME8Fku8nvQcGafpfLc+Lwpma+nGvg06w==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/tin": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "topojson-client": "3.x",
+        "topojson-server": "3.x",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/convex": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/convex/-/convex-7.3.4.tgz",
+      "integrity": "sha512-zeNv0fFdOoHuOQB7nl6OLb0DyjvzDvm0e3zlFkph50GF9pEKOmkCSmlniw681aWL2aRBdWZBnON3rRzOS+9C7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "concaveman": "^1.2.1",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/destination": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-7.3.4.tgz",
+      "integrity": "sha512-YxoUJwkKmTHiRFQxMQOP0tz8Vy+ga5EXl+C+F/WubjDLwT1AJu5y8CNIjLvWyjPWckj/vZG4u/1js5bx6MLADA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/difference": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-7.3.4.tgz",
+      "integrity": "sha512-kIxizNQrYLO2rtqUIeed0tPycicrXoipy/g9d4mjv91kzBEbwpyojz9zi8U9G1ISBfCEgA7wsViQD0r+8qzxXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "polyclip-ts": "^0.16.8",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/dissolve": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/dissolve/-/dissolve-7.3.4.tgz",
+      "integrity": "sha512-xjGY1gQ4icWhDgsW0YfU2KQtij1+ru34AfvtkVMQEgI86O9EwjW2r9Jq5DJY2PMKPbor3kz9yM/RTOiDP7f3Jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/flatten": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "polyclip-ts": "^0.16.8",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/distance": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-7.3.4.tgz",
+      "integrity": "sha512-9drWgd46uHPPyzgrcRQLgSvdS/SjVlQ6ZIBoRQagS5P2kSjUbcOXHIMeOSPwfxwlKhEtobLyr+IiR2ns1TfF8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/distance-weight": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/distance-weight/-/distance-weight-7.3.4.tgz",
+      "integrity": "sha512-dVMNEmIluKgn7iQTmzJJOe0UASRNmmSdFX1boAev5MISaW3AvPiURCCOV+lTIeoaQbWRpEAESbAp6JIimXFr8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/centroid": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/ellipse": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-7.3.4.tgz",
+      "integrity": "sha512-SMgbERZl12j7H8YaIofmnf0NwAvdF5Wly4tjI/eUhj/sFOKrKXOS1lvCSBJ6uSV9tFijl3ecGOVOlTpURdZ30g==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/destination": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/transform-rotate": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/envelope": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/envelope/-/envelope-7.3.4.tgz",
+      "integrity": "sha512-anXSjYMXGAyXT7rpO74VyRI0q/rPAbKE/MYvou+QvG0U/Oa7el0yF4JNNi9wKEAxXg/10aWm9kHp8s2caeLg6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/bbox-polygon": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/explode": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-7.3.4.tgz",
+      "integrity": "sha512-7QWhp3f8jhrWjvArhJ74hXBFHMaiJr/2Y1PzHCWue2/pC5MbbTV0o7peehwrrrJC/1uD6CVb3hlcb77IxtMQkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/flatten": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/flatten/-/flatten-7.3.4.tgz",
+      "integrity": "sha512-Yt3HCh/qeNaXS4LYhXczFhBfTeaKlTBoxEw1OICb9RT3SiGU0XCxuK7H0W26OLo7XxB0qP7GPs2L3FZbiri6wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/flip": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/flip/-/flip-7.3.4.tgz",
+      "integrity": "sha512-HME+kVMTyvcsYVY6dC6DTvuzq8vvDpw+C7PviEqpuT3KcVlBCoGPAqlWRdyWYOb9MDciOqNxvvJF/okpb/GQcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/geojson-rbush": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/geojson-rbush/-/geojson-rbush-7.3.4.tgz",
+      "integrity": "sha512-aDG/5mMCgKduqBwZ3XpLOdlE2hizV3fM+5dHCWyrBepCQLeM/QRvvpBDCdQKDWKpoIBmrGGYDNiOofnf3QmGhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "rbush": "^3.0.1",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/great-circle": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/great-circle/-/great-circle-7.3.4.tgz",
+      "integrity": "sha512-JvfzWFL9efP+xKtOnKzGvwEIXfaN0CLZoPPxNnWa/cVisLs9FVMlC9PWnuL3/3aqH5VhBHPddmU8ipzNE6KIIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "arc": "^0.2.0",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/helpers": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.4.tgz",
+      "integrity": "sha512-U/S5qyqgx3WTvg4twaH0WxF3EixoTCfDsmk98g1E3/5e2YKp7JKYZdz0vivsS5/UZLJeZDEElOSFH4pUgp+l7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/hex-grid": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/hex-grid/-/hex-grid-7.3.4.tgz",
+      "integrity": "sha512-TDCgBykFdsrP3IOOfToiiLpYkbUb3eEEhM9riIqWht0ubKUY61LN7qVs9bxZD83hG6XaDB6uY7SWkxK1zIEopQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/intersect": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/interpolate": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/interpolate/-/interpolate-7.3.4.tgz",
+      "integrity": "sha512-lwYSMbHxsXYEWObv0tyBCjwTLXyfsTvOLn/NFhlsGrNCYEXn8I1VPtLGwuxbSdF3hVRgurn8qftkB1npHrNs6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/centroid": "7.3.4",
+        "@turf/clone": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/hex-grid": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/point-grid": "7.3.4",
+        "@turf/square-grid": "7.3.4",
+        "@turf/triangle-grid": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/intersect": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-7.3.4.tgz",
+      "integrity": "sha512-VsqMEMeRWWs2mjwI7sTlUgH1cEfugTGhQ0nF8ncHG7YKd9HUUTzIKpn9FJeoguPWIYITcy1ar4yJEOU/hteBVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "polyclip-ts": "^0.16.8",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/invariant": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.4.tgz",
+      "integrity": "sha512-88Eo4va4rce9sNZs6XiMJowWkikM3cS2TBhaCKlU+GFHdNf8PFEpiU42VDU8q5tOF6/fu21Rvlke5odgOGW4AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/isobands": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/isobands/-/isobands-7.3.4.tgz",
+      "integrity": "sha512-SFYefwjQdQfF0MV0zfaSwNg9J1wD7mfPP8scGcScKGM3admbwS2A3V8rqPADBfYLD2eCPBDFnySxcl9SHbPung==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/area": "7.3.4",
+        "@turf/bbox": "7.3.4",
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/explode": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/isolines": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/isolines/-/isolines-7.3.4.tgz",
+      "integrity": "sha512-UFRIULkIgkZOmrhLxExWvguixbzfoCgVcXIqo2Cp68do4v+nwc3pTM7MTt4DBVFloIdX0Usrn4K44LQ/V05gxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/jsts": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@turf/jsts/-/jsts-2.7.2.tgz",
+      "integrity": "sha512-zAezGlwWHPyU0zxwcX2wQY3RkRpwuoBmhhNE9HY9kWhFDkCxZ3aWK5URKwa/SWKJbj9aztO+8vtdiBA28KVJFg==",
+      "license": "(EDL-1.0 OR EPL-1.0)",
+      "dependencies": {
+        "jsts": "2.7.1"
+      }
+    },
+    "node_modules/@turf/kinks": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/kinks/-/kinks-7.3.4.tgz",
+      "integrity": "sha512-LZTKELWxvXl0vc9ZxVgi0v07fO9+2FrZOam2B10fz/eGjy3oKNazU5gjggbnc499wEIcJS4hN+VyjQZrmsJAdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/length": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/length/-/length-7.3.4.tgz",
+      "integrity": "sha512-Dg1GnQ/B2go5NIWXt91N4L7XTjIgIWCftBSYIXkrpIM7QGjItzglek0Z5caytvb8ZRWXzZOGs8//+Q5we91WuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-arc": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/line-arc/-/line-arc-7.3.4.tgz",
+      "integrity": "sha512-nqZ+JKjDVIrvREFHgtJIP9Ps4WbWw3eStqdIzAPolrzoXyAZnpIKquyfRTxpJFYUUjDmf+uQ/SFWsPP4SOWAqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/circle": "7.3.4",
+        "@turf/destination": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-chunk": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/line-chunk/-/line-chunk-7.3.4.tgz",
+      "integrity": "sha512-xWEHR99EpUO5ZPEZhMfa0QvnFZC0W+QLxB1GcJcSeJAQ5ZMXUXY8doKF1Nztk0eppawMprEEO3nQWLvQoR4z2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/length": "7.3.4",
+        "@turf/line-slice-along": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-intersect": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-7.3.4.tgz",
+      "integrity": "sha512-XygbTvHa6A+v6l2ZKYtS8AAWxwmrPxKxfBbdH75uED1JvdytSLWYTKGlcU3soxd9sYb4x/g9sDvRIVyU6Lucrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "sweepline-intersections": "^1.5.0",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-offset": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/line-offset/-/line-offset-7.3.4.tgz",
+      "integrity": "sha512-CSrg3njde9Tx+C0oL+BHUpZYpgD+PEmzp0ldDNis5ZQiTe5tUrwiIyG7A/QXf9eDnGhtV1WhCAycX0Wjged4pg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-overlap": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/line-overlap/-/line-overlap-7.3.4.tgz",
+      "integrity": "sha512-3GBECiwNAQ2MmSwiqAHMweIl+EiePK0Jx4fXxF1KFE+NGCDv/MbGcEYfAbmsTg8mg6oRI9D8fJZzrT44DHpHXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-on-line": "7.3.4",
+        "@turf/geojson-rbush": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/line-segment": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/nearest-point-on-line": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "fast-deep-equal": "^3.1.3",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-segment": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-7.3.4.tgz",
+      "integrity": "sha512-UeISzf/JHoWEY5yeoyvKwA5epWcvJMCpCwbIMolvfTC5pp+IVozjHPVCRvRWuzmbmAvetcW0unL5bjqi0ADmuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-slice": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/line-slice/-/line-slice-7.3.4.tgz",
+      "integrity": "sha512-6Vt4Eptdr2C5T+jtpbo8D4v8b6X7KqYonPPyMB6huv+Kcg3nz4JRI9OQCDCaon9rWvU3ffWwjsjcbJCQS9o0sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/nearest-point-on-line": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-slice-along": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/line-slice-along/-/line-slice-along-7.3.4.tgz",
+      "integrity": "sha512-RT5HydNy8+m9Y3u39USeYZauG2EyMqCYoLnTpWcAxbZGdq9WjIwdzAwYir3d8eJkOzjlR6Khz071VM4Ufqs0Kg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bearing": "7.3.4",
+        "@turf/destination": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-split": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-7.3.4.tgz",
+      "integrity": "sha512-l1zmCSUnGsiN4gf22Aw91a2VnYs5DZS67FdkYqKgr+wPEAL/gpQgIBBWSTmhwY8zb3NEqty+f/gMEe8EJAWYng==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/geojson-rbush": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/line-intersect": "7.3.4",
+        "@turf/line-segment": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/nearest-point-on-line": "7.3.4",
+        "@turf/truncate": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-to-polygon": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/line-to-polygon/-/line-to-polygon-7.3.4.tgz",
+      "integrity": "sha512-vRnDHjzwOroC74/fsJEU+dUeGhiR/B2bG0/HeEWRBplAjmwVPptRBmDGtXKTz8sbA6or17/XtOITp3zTU0lBZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/mask": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/mask/-/mask-7.3.4.tgz",
+      "integrity": "sha512-FJIlSk8m0AiqzNoLSMdYuhDRif6aeOYVdW/WxjEjpUoMalwy2w5MMlZqJB9zxt/xSrMq6lvTWJgZfZfGL2s4ZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "polyclip-ts": "^0.16.8",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/meta": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.4.tgz",
+      "integrity": "sha512-tlmw9/Hs1p2n0uoHVm1w3ugw1I6L8jv9YZrcdQa4SH5FX5UY0ATrKeIvfA55FlL//PGuYppJp+eyg/0eb4goqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/midpoint": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/midpoint/-/midpoint-7.3.4.tgz",
+      "integrity": "sha512-/XAeGvsz8l5HaqcP7TUlexzGfibqXozQgBZ8rH7az6op2Dfm3pL/Z7bKLHoVavM0ccBg0Pt7g6j9NM54kZWdKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bearing": "7.3.4",
+        "@turf/destination": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/moran-index": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/moran-index/-/moran-index-7.3.4.tgz",
+      "integrity": "sha512-SNb16szwEG0OiyNn3z9zvSnk3M3tfwvvN8i//9UIC32APEApI+MRXCl93H/qZkKMhhh/cHA0pF0pjYZwl5z8Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance-weight": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-neighbor-analysis": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-neighbor-analysis/-/nearest-neighbor-analysis-7.3.4.tgz",
+      "integrity": "sha512-8EZlDy5poU0t7BDy8KTzOmfiGsAs2kWuB3/kgI4sMdbThKVk2P4hHKuToCSGvqAzwSy3B2qKYM1N6JeVWytu+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/area": "7.3.4",
+        "@turf/bbox": "7.3.4",
+        "@turf/bbox-polygon": "7.3.4",
+        "@turf/centroid": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/nearest-point": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-point": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point/-/nearest-point-7.3.4.tgz",
+      "integrity": "sha512-WfI09f2bX0nKx/jkO7zCt3tUrJulyAlUYQtZHP7lWYMCOmZ6Pq26D6lKWjpfs2it0OHbhlx1XF/UupEUaz830w==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-point-on-line": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-7.3.4.tgz",
+      "integrity": "sha512-DQrP3lRju83rIXFN68tUEpc7ki/eRwdwBkK2CTT4RAcyCxbcH2NGJPQv8dYiww/Ar77u1WLVn+aINXZH904dWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-point-to-line": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-to-line/-/nearest-point-to-line-7.3.4.tgz",
+      "integrity": "sha512-Nzp3ojQt0gDACNYG+oNWymRXAUCey0LzdiSezYtRwdA0/+FQCtuxP8Lbc8FftV10JL8D78/CRlmt7omaXLLXCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/point-to-line-distance": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/planepoint": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/planepoint/-/planepoint-7.3.4.tgz",
+      "integrity": "sha512-KAhMAnddbuWIEZuk2bK//g+xTeKn8aV9N2AaE27x6JMJyV/wqvatIuVVqEIXI3SkAFbhiVBpVuarvPYhrJ+fhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/point-grid": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/point-grid/-/point-grid-7.3.4.tgz",
+      "integrity": "sha512-9CL3OJ4dEt266+fxYlOQeRFqAY3XtsAuak2Gpk+K8k+Y3yGv8pvyn3QaAQ6P2npbiKt0zfG8Md/+HBAPOMPQ0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-within": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/point-on-feature": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/point-on-feature/-/point-on-feature-7.3.4.tgz",
+      "integrity": "sha512-tQfIxsJUxZqyO7OeJC25y3DqN9i4fmrAt4TBrPvZcIIwymgN7aMrElJKlg/dfi7JDihKp3h/CkWMjtMQA14Vwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/center": "7.3.4",
+        "@turf/explode": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/nearest-point": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/point-to-line-distance": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/point-to-line-distance/-/point-to-line-distance-7.3.4.tgz",
+      "integrity": "sha512-IdPAxlAQZj7FCZg+ObyVHlNdqwLL/oxYoQjpxMNJ511gNxokCtEv0aeRZQjYOYIxr9Ss97v3yo3ILJaF9V2kPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bearing": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/nearest-point-on-line": "7.3.4",
+        "@turf/projection": "7.3.4",
+        "@turf/rhumb-bearing": "7.3.4",
+        "@turf/rhumb-distance": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/point-to-polygon-distance": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/point-to-polygon-distance/-/point-to-polygon-distance-7.3.4.tgz",
+      "integrity": "sha512-VxbkgHyzCkYWSxirqSUqw+lzbYmTf2qFhVZ/T5dprhwyXWcgalpupvgRzmZmjKkgsoJ017vrvCNKZRaCCn+Z7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/point-to-line-distance": "7.3.4",
+        "@turf/polygon-to-line": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/points-within-polygon": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/points-within-polygon/-/points-within-polygon-7.3.4.tgz",
+      "integrity": "sha512-HfT83Iw99zywDfCp+nJwS+JDzH+GdNug0sut9WDjGEznHKoZyAcOk+hGKL/ja8TeCLx9VsZHOiVCQFm+NTgvgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/polygon-smooth": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-smooth/-/polygon-smooth-7.3.4.tgz",
+      "integrity": "sha512-AnpaGgNYVvP/dfz10id3AotDrUh9O+4unXCk3es1ff51VrpUhVgH3H+zyTSbVL4zAXN/ejPb8UnKCxDvNOQs4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/polygon-tangents": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-tangents/-/polygon-tangents-7.3.4.tgz",
+      "integrity": "sha512-D1IFocXJYF8PUMZ+BmnOstyRrzklqC86FgakYVk9O61F9Ki8LhMGaRfF+6reKMD473KvHvEf1M2EgmGt+OHDRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/boolean-within": "7.3.4",
+        "@turf/explode": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/nearest-point": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/polygon-to-line": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-7.3.4.tgz",
+      "integrity": "sha512-xhmOZ5rHZAKLUDLeYKWMsX84ip8CCGOcGLBHtPPYOjdIDHddMV6Sxt5kVgkmlZpK6NEWEmOD6lYR4obxHcHlGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/polygonize": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/polygonize/-/polygonize-7.3.4.tgz",
+      "integrity": "sha512-kmj05rkJ4tE8LvbQ4GVsL5GOrRiX/F5W4RIdxo8gPGTw1Y5oLG/1vFk6Hg6x63L1WcdNtF0sq6AdEI0G9BXWXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/envelope": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/projection": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-7.3.4.tgz",
+      "integrity": "sha512-p91zOaLmzoBHzU/2H6Ot1tOhTmAom85n1P7I4Oo0V9xU8hmJXWfNnomLFf/6rnkKDIFZkncLQIBz4iIecZ61sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/quadrat-analysis": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/quadrat-analysis/-/quadrat-analysis-7.3.4.tgz",
+      "integrity": "sha512-Yxqq8wgrDiXIX+s0uOZ2exmYfRwTIcUX8J7j4P+sbyLVbyN8W3AjN2s5ZX21P0aFf3v24FBd2fNWlm5VmMUAdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/area": "7.3.4",
+        "@turf/bbox": "7.3.4",
+        "@turf/bbox-polygon": "7.3.4",
+        "@turf/centroid": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/point-grid": "7.3.4",
+        "@turf/random": "7.3.4",
+        "@turf/square-grid": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/random": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/random/-/random-7.3.4.tgz",
+      "integrity": "sha512-CXMS5XDoI5x0zc1aCYbn3t603k8hjaFHNsSOvGBW20z68cwP0UwMQQr0KLqFPqI4J1O7dMX+urn8IHH27RXFYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rectangle-grid": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/rectangle-grid/-/rectangle-grid-7.3.4.tgz",
+      "integrity": "sha512-qM7vujJ4wndB4MKZlEcnUSawgvs5wXpSEFf4f+LWRIfmGhtv6serzDqFzWcmy8kF8hg5J465PMktRmAFWq/a+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-intersects": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rewind": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-7.3.4.tgz",
+      "integrity": "sha512-4BZ8MHMujl4NAT7XnIs7JoOuDhpR96oDTB0RtqTeIP4onioIedVnw1ZA3Uq08sILGpR0qKLuDsvdz4x9jtbptg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-clockwise": "7.3.4",
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rhumb-bearing": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-7.3.4.tgz",
+      "integrity": "sha512-tvX1toSo80q0iL0cUMMXpSKsCCfOjRqDGCmOdR6B9shhk6xP1ZM2PLQDr+MFPBFeGyQuyY4CNFkV2+3DF49vYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rhumb-destination": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-7.3.4.tgz",
+      "integrity": "sha512-6HikEb5nm2A18FQWk6vVLMQkc099I/7c69j47RYM27xQK8J8uBCNk1zLYyMPcZTh24xcNSbZ1iPHDsDOqw6wWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rhumb-distance": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-7.3.4.tgz",
+      "integrity": "sha512-phwskeijdgYMsR3qDQmytfsg2iZcp3uWK7UFc76wKTEpxozbDGFI4enX5gXvZPpyI1iD7gsktGqHsO33AjnFDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/sample": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/sample/-/sample-7.3.4.tgz",
+      "integrity": "sha512-XzAATg09c2XYAXkIBbg8lktSrU1tXNjJYXtbVwF6jLp1q2wTRpwb+mZpTEPAwzZwVF81uR5c0CsdQyr5UHINVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/sector": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/sector/-/sector-7.3.4.tgz",
+      "integrity": "sha512-x2tNAXl21HRcF302ghU5ohE/vmmfDcXpQKgoWHyi7o5Q9kDRBwy7kbvr5YxbT3vwW/kAWUDYM7FoXNH42bXgCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/circle": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/line-arc": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/shortest-path": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/shortest-path/-/shortest-path-7.3.4.tgz",
+      "integrity": "sha512-xbK/oM+JRL+lJCHkAdZ3QPgoivT40J9WKJ0d1Ddt8LXTpzX2YeJVgcwOZaBPG9ncZUzHfHIWS1rUjc54clnZcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/bbox-polygon": "7.3.4",
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/clean-coords": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/transform-scale": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/simplify": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/simplify/-/simplify-7.3.4.tgz",
+      "integrity": "sha512-OoSwu3vI0H9P+GzLDaOJIL9v0V8ubeP8wQjM8GeMEZrq6U2uh9JWQnAU+jviT3ODcKF5H+88snpiMik585L0wA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clean-coords": "7.3.4",
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/square": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/square/-/square-7.3.4.tgz",
+      "integrity": "sha512-vJ+NeiEaOVsb8YiUExtyIgvH+ZybthHszl2TASZn5q340ioKHPb2JeHGlbgrB2x8pEMh3MVhoqxAbXDuND/cnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/square-grid": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/square-grid/-/square-grid-7.3.4.tgz",
+      "integrity": "sha512-MgjlVRklQYFfQm9yJNha9kXothLPliVdeycNdmn4lWLH3SOZe1rqJPB5Z9+dhmJELT3BJraDq3W5ik5taEpKyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/rectangle-grid": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/standard-deviational-ellipse": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/standard-deviational-ellipse/-/standard-deviational-ellipse-7.3.4.tgz",
+      "integrity": "sha512-+BaetOKN8zA2mQCVTcRWMcfidNR3JkjmYj0r5iGRncK0J+pdxIjX2q6sF6yBMOOxMoEMy393P7j07HdBIPbibw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/center-mean": "7.3.4",
+        "@turf/ellipse": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/points-within-polygon": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/tag": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/tag/-/tag-7.3.4.tgz",
+      "integrity": "sha512-ienLhLzBLeChtKhbJMmU3/vGg0hWzi6Wh/q0n39W4CmdNb+yAoGQhlYjcCbPOJT4IcdFlWE3OhbP9EmH/xPgfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/tesselate": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/tesselate/-/tesselate-7.3.4.tgz",
+      "integrity": "sha512-NnDgVb5ZchJEhEpq1je2hktS5UhnHMfeeumxZQgnIoMeGILpJtcOL//b/1biBBUVSJ0ZZg5zxiHdQc1PgK2gxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "earcut": "^2.2.4",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/tesselate/node_modules/earcut": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
+      "license": "ISC"
+    },
+    "node_modules/@turf/tin": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/tin/-/tin-7.3.4.tgz",
+      "integrity": "sha512-tuegrGlbKPp6Dm8r5SuYDtQ2EVzdXVVxelqI1agnzj9N+l8oTBIKLRxRbBkLsizeVIDnlmVHCQB6cRc3v+u8JQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/transform-rotate": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-7.3.4.tgz",
+      "integrity": "sha512-pbUG6QLwyJvvitq4aAq4IQH79X8T0NmEPUGDUEEP69yW7t4+UZjDBAVbCKwpOc8gtsK0K5yvxlZ0e2CdtpNmEw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/centroid": "7.3.4",
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/rhumb-bearing": "7.3.4",
+        "@turf/rhumb-destination": "7.3.4",
+        "@turf/rhumb-distance": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/transform-scale": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/transform-scale/-/transform-scale-7.3.4.tgz",
+      "integrity": "sha512-7gUIFFHaU3Ewj3rCzIu5Yo7Zjfv4R2ypjh6UWiMJnDavb7RQ8fn0AKKcNMA/vF/yxuncp2l3zoa2gygv4AKM8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/center": "7.3.4",
+        "@turf/centroid": "7.3.4",
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/rhumb-bearing": "7.3.4",
+        "@turf/rhumb-destination": "7.3.4",
+        "@turf/rhumb-distance": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/transform-translate": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/transform-translate/-/transform-translate-7.3.4.tgz",
+      "integrity": "sha512-qbSIEueOR8mNB7p4EB88vHvUAyuSBM8zxP68UiiTNV3Gh+OZF2VXTFiu3EFYMTaD9sE6Lxmzvv3fjW8N2q82pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/rhumb-destination": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/triangle-grid": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/triangle-grid/-/triangle-grid-7.3.4.tgz",
+      "integrity": "sha512-0bki10XwYvNcPzDcSs5kUh3niOogdVeFtawJEz5FdlyTAUohbNlC+Vb40K//OqEyTrGII+q1/dE4q+1J6ZCmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/intersect": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/truncate": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-7.3.4.tgz",
+      "integrity": "sha512-VPXdae9+RLLM19FMrJgt7QANBikm7DxPbfp/dXgzE4Ca7v+mJ4T1fYc7gCZDaqOrWMccHKbvv4iSuW7YZWdIIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/turf": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/turf/-/turf-7.3.4.tgz",
+      "integrity": "sha512-uMAKLYt2tWJj8xIepq4vExF1r8fzJviP/5l/elDHuRyauI2mASy/Gox6kSFlrN0t0p8AT4Cs8o//4GuJTXyC+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/along": "7.3.4",
+        "@turf/angle": "7.3.4",
+        "@turf/area": "7.3.4",
+        "@turf/bbox": "7.3.4",
+        "@turf/bbox-clip": "7.3.4",
+        "@turf/bbox-polygon": "7.3.4",
+        "@turf/bearing": "7.3.4",
+        "@turf/bezier-spline": "7.3.4",
+        "@turf/boolean-clockwise": "7.3.4",
+        "@turf/boolean-concave": "7.3.4",
+        "@turf/boolean-contains": "7.3.4",
+        "@turf/boolean-crosses": "7.3.4",
+        "@turf/boolean-disjoint": "7.3.4",
+        "@turf/boolean-equal": "7.3.4",
+        "@turf/boolean-intersects": "7.3.4",
+        "@turf/boolean-overlap": "7.3.4",
+        "@turf/boolean-parallel": "7.3.4",
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/boolean-point-on-line": "7.3.4",
+        "@turf/boolean-touches": "7.3.4",
+        "@turf/boolean-valid": "7.3.4",
+        "@turf/boolean-within": "7.3.4",
+        "@turf/buffer": "7.3.4",
+        "@turf/center": "7.3.4",
+        "@turf/center-mean": "7.3.4",
+        "@turf/center-median": "7.3.4",
+        "@turf/center-of-mass": "7.3.4",
+        "@turf/centroid": "7.3.4",
+        "@turf/circle": "7.3.4",
+        "@turf/clean-coords": "7.3.4",
+        "@turf/clone": "7.3.4",
+        "@turf/clusters": "7.3.4",
+        "@turf/clusters-dbscan": "7.3.4",
+        "@turf/clusters-kmeans": "7.3.4",
+        "@turf/collect": "7.3.4",
+        "@turf/combine": "7.3.4",
+        "@turf/concave": "7.3.4",
+        "@turf/convex": "7.3.4",
+        "@turf/destination": "7.3.4",
+        "@turf/difference": "7.3.4",
+        "@turf/dissolve": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/distance-weight": "7.3.4",
+        "@turf/ellipse": "7.3.4",
+        "@turf/envelope": "7.3.4",
+        "@turf/explode": "7.3.4",
+        "@turf/flatten": "7.3.4",
+        "@turf/flip": "7.3.4",
+        "@turf/geojson-rbush": "7.3.4",
+        "@turf/great-circle": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/hex-grid": "7.3.4",
+        "@turf/interpolate": "7.3.4",
+        "@turf/intersect": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/isobands": "7.3.4",
+        "@turf/isolines": "7.3.4",
+        "@turf/kinks": "7.3.4",
+        "@turf/length": "7.3.4",
+        "@turf/line-arc": "7.3.4",
+        "@turf/line-chunk": "7.3.4",
+        "@turf/line-intersect": "7.3.4",
+        "@turf/line-offset": "7.3.4",
+        "@turf/line-overlap": "7.3.4",
+        "@turf/line-segment": "7.3.4",
+        "@turf/line-slice": "7.3.4",
+        "@turf/line-slice-along": "7.3.4",
+        "@turf/line-split": "7.3.4",
+        "@turf/line-to-polygon": "7.3.4",
+        "@turf/mask": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/midpoint": "7.3.4",
+        "@turf/moran-index": "7.3.4",
+        "@turf/nearest-neighbor-analysis": "7.3.4",
+        "@turf/nearest-point": "7.3.4",
+        "@turf/nearest-point-on-line": "7.3.4",
+        "@turf/nearest-point-to-line": "7.3.4",
+        "@turf/planepoint": "7.3.4",
+        "@turf/point-grid": "7.3.4",
+        "@turf/point-on-feature": "7.3.4",
+        "@turf/point-to-line-distance": "7.3.4",
+        "@turf/point-to-polygon-distance": "7.3.4",
+        "@turf/points-within-polygon": "7.3.4",
+        "@turf/polygon-smooth": "7.3.4",
+        "@turf/polygon-tangents": "7.3.4",
+        "@turf/polygon-to-line": "7.3.4",
+        "@turf/polygonize": "7.3.4",
+        "@turf/projection": "7.3.4",
+        "@turf/quadrat-analysis": "7.3.4",
+        "@turf/random": "7.3.4",
+        "@turf/rectangle-grid": "7.3.4",
+        "@turf/rewind": "7.3.4",
+        "@turf/rhumb-bearing": "7.3.4",
+        "@turf/rhumb-destination": "7.3.4",
+        "@turf/rhumb-distance": "7.3.4",
+        "@turf/sample": "7.3.4",
+        "@turf/sector": "7.3.4",
+        "@turf/shortest-path": "7.3.4",
+        "@turf/simplify": "7.3.4",
+        "@turf/square": "7.3.4",
+        "@turf/square-grid": "7.3.4",
+        "@turf/standard-deviational-ellipse": "7.3.4",
+        "@turf/tag": "7.3.4",
+        "@turf/tesselate": "7.3.4",
+        "@turf/tin": "7.3.4",
+        "@turf/transform-rotate": "7.3.4",
+        "@turf/transform-scale": "7.3.4",
+        "@turf/transform-translate": "7.3.4",
+        "@turf/triangle-grid": "7.3.4",
+        "@turf/truncate": "7.3.4",
+        "@turf/union": "7.3.4",
+        "@turf/unkink-polygon": "7.3.4",
+        "@turf/voronoi": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "@types/kdbush": "^3.0.5",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/union": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/union/-/union-7.3.4.tgz",
+      "integrity": "sha512-JJYyPMmGcrTa9sPv2ief2QU9Hb//cEAU1zgKu/OfoCMa9a8Imp5QVm9UTAkhGlc+4qm/N/X16iJ+cvVWaxPjkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "polyclip-ts": "^0.16.8",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/unkink-polygon": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/unkink-polygon/-/unkink-polygon-7.3.4.tgz",
+      "integrity": "sha512-dFIqTLAnLL5D3OANPJtRb5OvmOM81GlNCjwgjlLQy0xdpYgKwGdE+gNXjygDrPUUXNc22xnaj3EfAfC3Pq7W4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/area": "7.3.4",
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "rbush": "^3.0.1",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/voronoi": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/voronoi/-/voronoi-7.3.4.tgz",
+      "integrity": "sha512-cwKSiDzDHRnA7yafQ1zOhWxRuMzp+fYFFzadCdByBAG1jAD7UlFwKhS1fjNPBNs67Fl5X3LL5ahCLW5gEdFgmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/d3-voronoi": "^1.1.12",
+        "@types/geojson": "^7946.0.10",
+        "d3-voronoi": "1.1.2",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
@@ -2029,6 +4081,12 @@
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
     },
+    "node_modules/@types/d3-voronoi": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@types/d3-voronoi/-/d3-voronoi-1.1.12.tgz",
+      "integrity": "sha512-DauBl25PKZZ0WVJr42a6CNvI6efsdzofl9sajqZr2Gf5Gu733WkDdUGiPkUHXiUvYGzNNlFQde2wdZdfQPG+yw==",
+      "license": "MIT"
+    },
     "node_modules/@types/geojson": {
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
@@ -2044,10 +4102,31 @@
         "@types/geojson": "*"
       }
     },
+    "node_modules/@types/geokdbush": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/geokdbush/-/geokdbush-1.1.5.tgz",
+      "integrity": "sha512-jIsYnXY+RQ/YCyBqeEHxYN9mh+7PqKJUJUp84wLfZ7T2kqyVPNaXwZuvf1A2uQUkrvVqEbsG94ff8jH32AlLvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/kdbush": "^1"
+      }
+    },
+    "node_modules/@types/geokdbush/node_modules/@types/kdbush": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@types/kdbush/-/kdbush-1.0.7.tgz",
+      "integrity": "sha512-QM5iB8m/0mnGOjUKshErIZQ0LseyTieRSYc3yaOpmrRM0xbWiOuJUWlduJx+TPNK7/VFMWphUGwx3nus7eT1Wg==",
+      "license": "MIT"
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
+    },
+    "node_modules/@types/kdbush": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/kdbush/-/kdbush-3.0.5.tgz",
+      "integrity": "sha512-tdJz7jaWFu4nR+8b2B+CdPZ6811ighYylWsu2hpsivapzW058yP0KdfZuNY89IiRe5jbKvBGXN3LQdN2KPXVdQ==",
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "20.6.2",
@@ -2092,6 +4171,17 @@
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.23.0.tgz",
       "integrity": "sha512-YIoDCTH3Af6XM5VuwGG/QL/CJqga1Zm3NkU3HZ4ZHK2fRMPYP1VczsTUqtsf43PH/iJNVlPHAo2oWX7BSdB2Hw=="
+    },
+    "node_modules/@types/shpjs": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@types/shpjs/-/shpjs-3.4.7.tgz",
+      "integrity": "sha512-/6PjggpFsq9NFxar6ZpXsnYZ+nQJR8Cv03Gne1enIJuMZ/eFVOpu0orHxL9D7RT3ciJElzF2H6l+49US23ydUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*",
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/supercluster": {
       "version": "7.1.3",
@@ -2301,6 +4391,14 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/arc": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/arc/-/arc-0.2.0.tgz",
+      "integrity": "sha512-8NFOo126uYKQJyXNSLY/jSklgfLQL+XWAcPXGo876JwEQ8nSOPXWNI3TV2jLZMN8QEw8uksJ1ZwS4npjBca8MA==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/arg": {
@@ -2558,6 +4656,15 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -2630,6 +4737,12 @@
       "engines": {
         "node": ">=10.16.0"
       }
+    },
+    "node_modules/but-unzip": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/but-unzip/-/but-unzip-0.1.10.tgz",
+      "integrity": "sha512-hLfQ9WlUimmv/okzsRl6AYG3Ew5HNWhWgUslSR93FsDdeL0MAoQvmC/BJfs35lqEAO5t/QD7Y4vCFcPJtijt3A==",
+      "license": "Apache-2.0"
     },
     "node_modules/call-bind": {
       "version": "1.0.7",
@@ -3160,6 +5273,24 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
+    "node_modules/concaveman": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/concaveman/-/concaveman-1.2.1.tgz",
+      "integrity": "sha512-PwZYKaM/ckQSa8peP5JpVr7IMJ4Nn/MHIaWUjP4be+KoZ7Botgs8seAZGpmaOM+UZXawcdYRao/px9ycrCihHw==",
+      "license": "ISC",
+      "dependencies": {
+        "point-in-polygon": "^1.1.0",
+        "rbush": "^3.0.1",
+        "robust-predicates": "^2.0.4",
+        "tinyqueue": "^2.0.3"
+      }
+    },
+    "node_modules/concaveman/node_modules/tinyqueue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
+      "license": "ISC"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -3229,6 +5360,21 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/d3-geo": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.7.1.tgz",
+      "integrity": "sha512-O4AempWAr+P5qbk2bC2FuN/sDW4z+dN2wDf9QV3bxQt4M5HfOEeXLgJ/UKQW0+o1Dj8BE+L5kiDbdWUMjsmQpw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1"
+      }
+    },
+    "node_modules/d3-geo/node_modules/d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/d3-interpolate": {
       "version": "3.0.1",
@@ -3304,6 +5450,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/d3-voronoi": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
+      "integrity": "sha512-RhGS1u2vavcO7ay7ZNAPo4xeDh/VYeGof3x5ZLJBQgYhLegxr3s5IykvWmJ94FTU6mcbtp4sloqZ54mP6R4Utw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -4351,10 +6503,58 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/geojson-equality-ts": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/geojson-equality-ts/-/geojson-equality-ts-1.0.2.tgz",
+      "integrity": "sha512-h3Ryq+0mCSN/7yLs0eDgrZhvc9af23o/QuC4aTiuuzP/MRCtd6mf5rLsLRY44jX0RPUfM8c4GqERQmlUxPGPoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.14"
+      }
+    },
+    "node_modules/geojson-polygon-self-intersections": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/geojson-polygon-self-intersections/-/geojson-polygon-self-intersections-1.2.2.tgz",
+      "integrity": "sha512-6XRNF4CsRHYmR9z5YuIk5f/aOototnDf0dgMqYGcS7y1l57ttt6MAIAxl3rXyas6lq1HEbTuLMh4PgvO+OV42w==",
+      "license": "MIT",
+      "dependencies": {
+        "rbush": "^2.0.1"
+      }
+    },
+    "node_modules/geojson-polygon-self-intersections/node_modules/quickselect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
+      "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ==",
+      "license": "ISC"
+    },
+    "node_modules/geojson-polygon-self-intersections/node_modules/rbush": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
+      "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
+      "license": "MIT",
+      "dependencies": {
+        "quickselect": "^1.0.1"
+      }
+    },
     "node_modules/geojson-vt": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.2.tgz",
       "integrity": "sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A==",
+      "license": "ISC"
+    },
+    "node_modules/geokdbush": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/geokdbush/-/geokdbush-2.0.1.tgz",
+      "integrity": "sha512-0M8so1Qx6+jJ1xpirpCNrgUsWAzIcQ3LrLmh0KJPBYI3gH7vy70nY5zEEjSp9Tn0nBt6Q2Fh922oL08lfib4Zg==",
+      "license": "ISC",
+      "dependencies": {
+        "tinyqueue": "^2.0.3"
+      }
+    },
+    "node_modules/geokdbush/node_modules/tinyqueue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
       "license": "ISC"
     },
     "node_modules/get-intrinsic": {
@@ -5139,6 +7339,15 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/jsts": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/jsts/-/jsts-2.7.1.tgz",
+      "integrity": "sha512-x2wSZHEBK20CY+Wy+BPE7MrFQHW6sIsdaGUMEqmGAio+3gFzQaBYPwLRonUfQf9Ak8pBieqj9tUofX1+WtAEIg==",
+      "license": "(EDL-1.0 OR EPL-1.0)",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -5312,6 +7521,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/mgrs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mgrs/-/mgrs-1.0.0.tgz",
+      "integrity": "sha512-awNbTOqCxK1DBGjalK3xqWIstBZgN6fxsMSiXLs9/spqWkF2pAhb2rrYCFSsr1/tT7PhcDGjZndG8SWYn0byYA==",
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -5696,6 +7911,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/parsedbf": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parsedbf/-/parsedbf-2.0.0.tgz",
+      "integrity": "sha512-WNjKn/cwgGBkXqQLif+2VMEahcRHkBRU0/RfBWZ7Vj7snRNNW63yW1mVuuHRDyXTRxuGCzAHHBcr/Fn+U/bXjQ==",
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5790,6 +8011,37 @@
       "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/point-in-polygon": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/point-in-polygon/-/point-in-polygon-1.1.0.tgz",
+      "integrity": "sha512-3ojrFwjnnw8Q9242TzgXuTD+eKiutbzyslcq1ydfu82Db2y+Ogbmyrkpv0Hgj31qwT3lbS9+QAAO/pIQM35XRw==",
+      "license": "MIT"
+    },
+    "node_modules/point-in-polygon-hao": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/point-in-polygon-hao/-/point-in-polygon-hao-1.2.4.tgz",
+      "integrity": "sha512-x2pcvXeqhRHlNRdhLs/tgFapAbSSe86wa/eqmj1G6pWftbEs5aVRJhRGM6FYSUERKu0PjekJzMq0gsI2XyiclQ==",
+      "license": "MIT",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
+    "node_modules/point-in-polygon-hao/node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
+    "node_modules/polyclip-ts": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/polyclip-ts/-/polyclip-ts-0.16.8.tgz",
+      "integrity": "sha512-JPtKbDRuPEuAjuTdhR62Gph7Is2BS1Szx69CFOO3g71lpJDFo78k4tFyi+qFOMVPePEzdSKkpGU3NBXPHHjvKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.1.0",
+        "splaytree-ts": "^1.0.2"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -5961,6 +8213,19 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/proj4": {
+      "version": "2.20.4",
+      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.20.4.tgz",
+      "integrity": "sha512-/EEBoXjBw+zW1Lofinw0YFQ4OFOqC6XThnwRAgjEHw8WBN+wSy/6aeqRRdjy4b2igy3X0k3RNDuwcYqcQq7nDw==",
+      "license": "MIT",
+      "dependencies": {
+        "mgrs": "1.0.0",
+        "wkt-parser": "^1.5.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ahocevar"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -6008,6 +8273,21 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
       "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "license": "ISC"
+    },
+    "node_modules/rbush": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
+      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+      "license": "MIT",
+      "dependencies": {
+        "quickselect": "^2.0.0"
+      }
+    },
+    "node_modules/rbush/node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
       "license": "ISC"
     },
     "node_modules/react": {
@@ -6456,6 +8736,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/shpjs": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/shpjs/-/shpjs-6.2.0.tgz",
+      "integrity": "sha512-8cR/RKYHQepmVyBMtzZQ+1bnSbWrtLXS6aoEJmpUlOSHtSUddterebVxYmIWq2g9kOEX9jm2kjHiikyPX7cNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "but-unzip": "^0.1.4",
+        "parsedbf": "^2.0.0",
+        "proj4": "^2.1.4"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
@@ -6483,6 +8774,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/skmeans": {
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/skmeans/-/skmeans-0.9.7.tgz",
+      "integrity": "sha512-hNj1/oZ7ygsfmPZ7ZfN5MUBRoGg1gtpnImuJBgLO0ljQ67DtJuiQaiYdS4lUA6s0KCwnPhGivtC/WRwIZLkHyg==",
+      "license": "MIT"
     },
     "node_modules/slash": {
       "version": "3.0.0",
@@ -6514,6 +8811,12 @@
       "resolved": "https://registry.npmjs.org/splaytree/-/splaytree-0.1.4.tgz",
       "integrity": "sha512-D50hKrjZgBzqD3FT2Ek53f2dcDLAQT8SSGrzj3vidNH5ISRgceeGVJ2dQIthKOuayqFXfFjXheHNo4bbt9LhRQ==",
       "license": "MIT"
+    },
+    "node_modules/splaytree-ts": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/splaytree-ts/-/splaytree-ts-1.0.2.tgz",
+      "integrity": "sha512-0kGecIZNIReCSiznK3uheYB8sbstLjCZLiwcQwbmLhgHJj2gz6OnSPkVzJQCMnmEz1BQ4gPK59ylhBoEWOhGNA==",
+      "license": "BDS-3-Clause"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.0.0",
@@ -6840,6 +9143,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sweepline-intersections": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sweepline-intersections/-/sweepline-intersections-1.5.0.tgz",
+      "integrity": "sha512-AoVmx72QHpKtItPu72TzFL+kcYjd67BPLDoR0LarIk+xyaRg+pDTMFXndIEvZf9xEKnJv6JdhgRMnocoG0D3AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tinyqueue": "^2.0.0"
+      }
+    },
+    "node_modules/sweepline-intersections/node_modules/tinyqueue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
+      "license": "ISC"
+    },
     "node_modules/tailwind-merge": {
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.5.3.tgz",
@@ -6947,6 +9265,44 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/topojson-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "topo2geo": "bin/topo2geo",
+        "topomerge": "bin/topomerge",
+        "topoquantize": "bin/topoquantize"
+      }
+    },
+    "node_modules/topojson-client/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
+    "node_modules/topojson-server": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/topojson-server/-/topojson-server-3.0.1.tgz",
+      "integrity": "sha512-/VS9j/ffKr2XAOjlZ9CgyyeLmgJ9dMwq6Y0YEON8O7p/tGGk+dCWnrE03zEdu7i4L7YsFZLEPZPzCvcB7lEEXw==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "geo2topo": "bin/geo2topo"
+      }
+    },
+    "node_modules/topojson-server/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -6980,9 +9336,10 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -7331,6 +9688,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/wkt-parser": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.5.4.tgz",
+      "integrity": "sha512-heRp3QBynj8SAGepAkE8h2k4KhUGRqzgwlSRgqNhxjmSIeSvE5ZrV8n1uy5jk+iJO2jmfffIwjdAaTirBOOx0A==",
+      "license": "MIT"
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@radix-ui/react-toggle-group": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.1.2",
     "@supabase/supabase-js": "^2.58.0",
+    "@turf/turf": "^7.3.4",
     "@types/node": "20.6.2",
     "@types/react": "18.2.22",
     "@types/react-dom": "18.2.7",
@@ -64,6 +65,7 @@
     "react-hook-form": "^7.53.0",
     "react-resizable-panels": "^2.1.3",
     "recharts": "^2.12.7",
+    "shpjs": "^6.2.0",
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.5.2",
     "tailwindcss": "3.3.3",
@@ -71,5 +73,8 @@
     "typescript": "5.2.2",
     "vaul": "^0.9.9",
     "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/shpjs": "^3.4.7"
   }
 }

--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -1,0 +1,8 @@
+# Supabase
+.branches
+.temp
+
+# dotenvx
+.env.keys
+.env.local
+.env.*.local

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,405 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "operations-center-api-demo"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# Maximum amount of time to wait for health check when starting the local database.
+health_timeout = "2m"
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Specifies an ordered list of schema files that describe your database.
+# Supports glob patterns relative to supabase directory: "./schemas/*.sql"
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[db.network_restrictions]
+# Enable management of network restrictions.
+enabled = false
+# List of IPv4 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv4 connections. Set empty array to block all IPs.
+allowed_cidrs = ["0.0.0.0/0"]
+# List of IPv6 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv6 connections. Set empty array to block all IPs.
+allowed_cidrs_v6 = ["::/0"]
+
+# Uncomment to reject non-secure connections to the database.
+# [db.ssl_enforcement]
+# enabled = true
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+[storage.buckets.shapefiles]
+public = true
+file_size_limit = "100MiB"
+allowed_mime_types = ["application/zip", "application/octet-stream"]
+
+# Allow connections via S3 compatible clients
+[storage.s3_protocol]
+enabled = true
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Store analytical data in S3 for running ETL jobs over Iceberg Catalog
+# This feature is only available on the hosted platform.
+[storage.analytics]
+enabled = false
+max_namespaces = 5
+max_tables = 10
+max_catalogs = 2
+
+# Analytics Buckets is available to Supabase Pro plan.
+# [storage.analytics.buckets.my-warehouse]
+
+# Store vector embeddings in S3 for large and durable datasets
+# This feature is only available on the hosted platform.
+[storage.vector]
+enabled = false
+max_buckets = 10
+max_indexes = 5
+
+# Vector Buckets is available to Supabase Pro plan.
+# [storage.vector.buckets.documents-openai]
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# JWT issuer URL. If not set, defaults to the local API URL (http://127.0.0.1:<port>/auth/v1).
+# jwt_issuer = ""
+# Path to JWT signing key. DO NOT commit your signing keys file to git.
+# signing_keys_path = "./signing_keys.json"
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+# Uncomment to customize notification email template
+# [auth.email.notification.password_changed]
+# enabled = true
+# subject = "Your password has been changed"
+# content_path = "./templates/password_changed_notification.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ .Code }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
+# [auth.hook.before_user_created]
+# enabled = true
+# uri = "pg-functions://postgres/auth/before-user-created-hook"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `x`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth redirectUrl.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+# If enabled, it will allow the user to successfully authenticate when the provider does not return an email address.
+email_optional = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
+
+[edge_runtime]
+enabled = true
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 2
+
+[edge_runtime.secrets]
+JOHN_DEERE_CLIENT_ID = "env(JOHN_DEERE_CLIENT_ID)"
+JOHN_DEERE_CLIENT_SECRET = "env(JOHN_DEERE_CLIENT_SECRET)"
+SUPABASE_PUBLIC_URL = "env(NEXT_PUBLIC_SUPABASE_URL)"
+
+[functions.john-deere-auth]
+verify_jwt = false
+
+[functions.john-deere-api]
+verify_jwt = false
+
+[functions.john-deere-irrigation]
+verify_jwt = false
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"
+
+# [experimental.pgdelta]
+# When enabled, pg-delta becomes the active engine for supported schema flows.
+# enabled = false
+# Directory under `supabase/` where declarative files are written.
+# declarative_schema_path = "./declarative"
+# JSON string passed through to pg-delta SQL formatting.
+# format_options = "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":80,\"commaStyle\":\"trailing\"}"

--- a/supabase/functions/_shared/auth.ts
+++ b/supabase/functions/_shared/auth.ts
@@ -1,0 +1,34 @@
+import { createClient, SupabaseClient, User } from "npm:@supabase/supabase-js@2";
+import { errorResponse } from "./cors.ts";
+
+export function createServiceClient(): SupabaseClient {
+  const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+  const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+  return createClient(supabaseUrl, supabaseServiceKey);
+}
+
+export interface AuthResult {
+  user: User;
+  supabase: SupabaseClient;
+}
+
+export async function getAuthenticatedUser(req: Request): Promise<AuthResult | Response> {
+  const authHeader = req.headers.get("Authorization");
+  if (!authHeader) {
+    return errorResponse("No authorization header", 401);
+  }
+
+  const supabase = createServiceClient();
+  const token = authHeader.replace("Bearer ", "");
+  const { data: { user }, error: userError } = await supabase.auth.getUser(token);
+
+  if (userError || !user) {
+    return errorResponse("Invalid user token", 401);
+  }
+
+  return { user, supabase };
+}
+
+export function isResponse(result: AuthResult | Response): result is Response {
+  return result instanceof Response;
+}

--- a/supabase/functions/_shared/boundaries.ts
+++ b/supabase/functions/_shared/boundaries.ts
@@ -1,0 +1,119 @@
+// Types matching John Deere boundary API responses
+export interface JdLink { rel: string; uri: string; }
+export interface JdBoundaryPoint { lat: number; lon: number; }
+export interface JdRing { points: JdBoundaryPoint[]; type: string; passable?: boolean; }
+export interface JdPolygon { rings: JdRing[]; }
+export interface JdMeasurement { valueAsDouble: number; unit: string; }
+export interface JdBoundary {
+  id: string;
+  name?: string;
+  multipolygons: JdPolygon[];
+  area?: JdMeasurement;
+  workableArea?: JdMeasurement;
+  active: boolean;
+  irrigated?: boolean;
+  links?: JdLink[];
+}
+export interface JdClient { id: string; name: string; links?: JdLink[]; }
+export interface JdFarm { id: string; name: string; links?: JdLink[]; }
+export interface JdClientsEmbed { clients?: JdClient[]; }
+export interface JdFarmsEmbed { farms?: JdFarm[]; }
+export interface JdField {
+  id: string;
+  name: string;
+  activeBoundary?: JdBoundary;
+  boundaries?: JdBoundary[];
+  clients?: JdClient[] | JdClientsEmbed;
+  farms?: JdFarm[] | JdFarmsEmbed;
+  links: JdLink[];
+}
+
+function closeRing(coords: number[][]): number[][] {
+  if (coords.length > 0 && (coords[0][0] !== coords[coords.length - 1][0] || coords[0][1] !== coords[coords.length - 1][1])) {
+    coords.push([...coords[0]]);
+  }
+  return coords;
+}
+
+function pointsToCoords(points: JdBoundaryPoint[]): number[][] {
+  return points.map((p) => [p.lon, p.lat]);
+}
+
+/**
+ * Convert a JD boundary to a GeoJSON MultiPolygon.
+ * Exterior and interior rings are preserved in the standard GeoJSON structure.
+ */
+export function convertBoundaryToGeoJSON(boundary: JdBoundary): { type: "MultiPolygon"; coordinates: number[][][][] } | null {
+  if (!boundary.multipolygons || boundary.multipolygons.length === 0) return null;
+
+  const polygons: number[][][][] = [];
+
+  for (const polygon of boundary.multipolygons) {
+    const exteriorRings = (polygon.rings || []).filter((r) => r.type === "exterior");
+    const interiorRings = (polygon.rings || []).filter((r) => r.type === "interior");
+
+    for (const ring of exteriorRings) {
+      const coords = closeRing(pointsToCoords(ring.points));
+      const polyRings: number[][][] = [coords];
+      for (const hole of interiorRings) {
+        polyRings.push(closeRing(pointsToCoords(hole.points)));
+      }
+      polygons.push(polyRings);
+    }
+  }
+
+  if (polygons.length === 0) return null;
+  return { type: "MultiPolygon", coordinates: polygons };
+}
+
+/**
+ * Build a GeoJSON Polygon from only the exterior rings of a boundary (no holes).
+ * Useful for calculating total field area.
+ */
+export function buildExteriorOnlyGeoJSON(boundary: JdBoundary): { type: "MultiPolygon"; coordinates: number[][][][] } | null {
+  if (!boundary.multipolygons || boundary.multipolygons.length === 0) return null;
+
+  const polygons: number[][][][] = [];
+
+  for (const polygon of boundary.multipolygons) {
+    const exteriorRings = (polygon.rings || []).filter((r) => r.type === "exterior");
+    for (const ring of exteriorRings) {
+      polygons.push([closeRing(pointsToCoords(ring.points))]);
+    }
+  }
+
+  if (polygons.length === 0) return null;
+  return { type: "MultiPolygon", coordinates: polygons };
+}
+
+/**
+ * Extract interior rings as individual GeoJSON Polygons.
+ * Each interior ring (e.g., a dryland corner outside a pivot) becomes its own polygon.
+ */
+export function buildInteriorRingPolygons(boundary: JdBoundary): Array<{ type: "Polygon"; coordinates: number[][][] }> {
+  const result: Array<{ type: "Polygon"; coordinates: number[][][] }> = [];
+
+  for (const polygon of boundary.multipolygons || []) {
+    const interiorRings = (polygon.rings || []).filter((r) => r.type === "interior");
+    for (const ring of interiorRings) {
+      const coords = closeRing(pointsToCoords(ring.points));
+      result.push({ type: "Polygon", coordinates: [coords] });
+    }
+  }
+
+  return result;
+}
+
+export function extractClients(field: JdField): JdClient[] {
+  if (!field.clients) return [];
+  if (Array.isArray(field.clients)) return field.clients;
+  if ((field.clients as JdClientsEmbed).clients) return (field.clients as JdClientsEmbed).clients!;
+  return [];
+}
+
+export function extractFarms(field: JdField): JdFarm[] {
+  if (!field.farms) return [];
+  if (Array.isArray(field.farms)) return field.farms;
+  if ((field.farms as JdFarmsEmbed).farms) return (field.farms as JdFarmsEmbed).farms!;
+  return [];
+}

--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -1,0 +1,20 @@
+export const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization, X-Client-Info, Apikey",
+};
+
+export function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+export function errorResponse(error: string, status = 400, details?: string): Response {
+  return jsonResponse({ error, ...(details ? { details } : {}) }, status);
+}
+
+export function optionsResponse(): Response {
+  return new Response(null, { status: 200, headers: corsHeaders });
+}

--- a/supabase/functions/_shared/john-deere.ts
+++ b/supabase/functions/_shared/john-deere.ts
@@ -1,0 +1,129 @@
+import { SupabaseClient } from "npm:@supabase/supabase-js@2";
+
+export const JOHN_DEERE_API_BASE = "https://sandboxapi.deere.com/platform";
+export const JOHN_DEERE_TOKEN_URL = "https://signin.johndeere.com/oauth2/aus78tnlaysMraFhC1t7/v1/token";
+export const JOHN_DEERE_CLIENT_ID = Deno.env.get("JOHN_DEERE_CLIENT_ID") || "";
+export const JOHN_DEERE_CLIENT_SECRET = Deno.env.get("JOHN_DEERE_CLIENT_SECRET") || "";
+
+export interface TokenResponse {
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+  token_type: string;
+  scope: string;
+}
+
+export interface Connection {
+  id: string;
+  user_id: string;
+  access_token: string;
+  refresh_token: string;
+  token_expires_at: string;
+  selected_org_id: string | null;
+  selected_org_name: string | null;
+}
+
+export async function exchangeCodeForTokens(code: string, redirectUri: string): Promise<TokenResponse> {
+  const params = new URLSearchParams({
+    grant_type: "authorization_code",
+    code,
+    redirect_uri: redirectUri,
+    client_id: JOHN_DEERE_CLIENT_ID,
+    client_secret: JOHN_DEERE_CLIENT_SECRET,
+  });
+
+  const response = await fetch(JOHN_DEERE_TOKEN_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "Accept": "application/json",
+    },
+    body: params.toString(),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Token exchange failed: ${response.status} ${errorText}`);
+  }
+
+  return response.json();
+}
+
+export async function refreshAccessToken(refreshToken: string): Promise<TokenResponse> {
+  const params = new URLSearchParams({
+    grant_type: "refresh_token",
+    refresh_token: refreshToken,
+    client_id: JOHN_DEERE_CLIENT_ID,
+    client_secret: JOHN_DEERE_CLIENT_SECRET,
+  });
+
+  const response = await fetch(JOHN_DEERE_TOKEN_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "Accept": "application/json",
+    },
+    body: params.toString(),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Token refresh failed: ${response.status} ${errorText}`);
+  }
+
+  return response.json();
+}
+
+export async function getValidToken(supabase: SupabaseClient, connection: Connection): Promise<string> {
+  const expiresAt = new Date(connection.token_expires_at);
+  const now = new Date();
+  const bufferMs = 5 * 60 * 1000;
+
+  if (expiresAt.getTime() - now.getTime() > bufferMs) {
+    return connection.access_token;
+  }
+
+  const tokens = await refreshAccessToken(connection.refresh_token);
+  const newExpiresAt = new Date(Date.now() + tokens.expires_in * 1000).toISOString();
+
+  await supabase
+    .from("john_deere_connections")
+    .update({
+      access_token: tokens.access_token,
+      refresh_token: tokens.refresh_token,
+      token_expires_at: newExpiresAt,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", connection.id);
+
+  return tokens.access_token;
+}
+
+export async function callJohnDeereApi(accessToken: string, endpoint: string): Promise<Response> {
+  return fetch(`${JOHN_DEERE_API_BASE}${endpoint}`, {
+    headers: {
+      "Authorization": `Bearer ${accessToken}`,
+      "Accept": "application/vnd.deere.axiom.v3+json",
+    },
+  });
+}
+
+export async function callJohnDeereUrl(accessToken: string, fullUrl: string): Promise<Response> {
+  return fetch(fullUrl, {
+    headers: {
+      "Authorization": `Bearer ${accessToken}`,
+      "Accept": "application/vnd.deere.axiom.v3+json",
+    },
+  });
+}
+
+export async function getUserConnection(supabase: SupabaseClient, userId: string): Promise<Connection | null> {
+  const { data, error } = await supabase
+    .from("john_deere_connections")
+    .select("*")
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (error || !data) return null;
+  return data as Connection;
+}

--- a/supabase/functions/john-deere-api/index.ts
+++ b/supabase/functions/john-deere-api/index.ts
@@ -1,123 +1,24 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
-import { createClient } from "npm:@supabase/supabase-js@2";
-
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
-  "Access-Control-Allow-Headers": "Content-Type, Authorization, X-Client-Info, Apikey",
-};
-
-const JOHN_DEERE_API_BASE = "https://sandboxapi.deere.com/platform";
-const JOHN_DEERE_TOKEN_URL = "https://signin.johndeere.com/oauth2/aus78tnlaysMraFhC1t7/v1/token";
-const JOHN_DEERE_CLIENT_ID = Deno.env.get("JOHN_DEERE_CLIENT_ID") || "";
-const JOHN_DEERE_CLIENT_SECRET = Deno.env.get("JOHN_DEERE_CLIENT_SECRET") || "";
-
-interface Connection {
-  id: string;
-  user_id: string;
-  access_token: string;
-  refresh_token: string;
-  token_expires_at: string;
-  selected_org_id: string | null;
-  selected_org_name: string | null;
-}
-
-async function refreshAccessToken(refreshToken: string): Promise<{ access_token: string; refresh_token: string; expires_in: number }> {
-  const params = new URLSearchParams({
-    grant_type: "refresh_token",
-    refresh_token: refreshToken,
-    client_id: JOHN_DEERE_CLIENT_ID,
-    client_secret: JOHN_DEERE_CLIENT_SECRET,
-  });
-
-  const response = await fetch(JOHN_DEERE_TOKEN_URL, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-      "Accept": "application/json",
-    },
-    body: params.toString(),
-  });
-
-  if (!response.ok) {
-    throw new Error(`Token refresh failed: ${response.status}`);
-  }
-
-  return response.json();
-}
-
-async function getValidToken(supabase: ReturnType<typeof createClient>, connection: Connection): Promise<string> {
-  const expiresAt = new Date(connection.token_expires_at);
-  const now = new Date();
-  const bufferMs = 5 * 60 * 1000;
-
-  if (expiresAt.getTime() - now.getTime() > bufferMs) {
-    return connection.access_token;
-  }
-
-  const tokens = await refreshAccessToken(connection.refresh_token);
-  const newExpiresAt = new Date(Date.now() + tokens.expires_in * 1000).toISOString();
-
-  await supabase
-    .from("john_deere_connections")
-    .update({
-      access_token: tokens.access_token,
-      refresh_token: tokens.refresh_token,
-      token_expires_at: newExpiresAt,
-      updated_at: new Date().toISOString(),
-    })
-    .eq("id", connection.id);
-
-  return tokens.access_token;
-}
-
-async function callJohnDeereApi(accessToken: string, endpoint: string): Promise<Response> {
-  const response = await fetch(`${JOHN_DEERE_API_BASE}${endpoint}`, {
-    headers: {
-      "Authorization": `Bearer ${accessToken}`,
-      "Accept": "application/vnd.deere.axiom.v3+json",
-    },
-  });
-
-  return response;
-}
-
-async function callJohnDeereUrl(accessToken: string, fullUrl: string): Promise<Response> {
-  const response = await fetch(fullUrl, {
-    headers: {
-      "Authorization": `Bearer ${accessToken}`,
-      "Accept": "application/vnd.deere.axiom.v3+json",
-    },
-  });
-
-  return response;
-}
-
-interface JdLink { rel: string; uri: string; }
-interface JdBoundaryPoint { lat: number; lon: number; }
-interface JdRing { points: JdBoundaryPoint[]; type: string; }
-interface JdPolygon { rings: JdRing[]; }
-interface JdMeasurement { valueAsDouble: number; unit: string; }
-interface JdBoundary { multipolygons: JdPolygon[]; area?: JdMeasurement; active: boolean; }
-interface JdClient { id: string; name: string; links?: JdLink[]; }
-interface JdFarm { id: string; name: string; links?: JdLink[]; }
-interface JdClientsEmbed { clients?: JdClient[]; }
-interface JdFarmsEmbed { farms?: JdFarm[]; }
-interface JdField { id: string; name: string; activeBoundary?: JdBoundary; boundaries?: JdBoundary[]; clients?: JdClient[] | JdClientsEmbed; farms?: JdFarm[] | JdFarmsEmbed; links: JdLink[]; }
-
-function extractClients(field: JdField): JdClient[] {
-  if (!field.clients) return [];
-  if (Array.isArray(field.clients)) return field.clients;
-  if ((field.clients as JdClientsEmbed).clients) return (field.clients as JdClientsEmbed).clients!;
-  return [];
-}
-
-function extractFarms(field: JdField): JdFarm[] {
-  if (!field.farms) return [];
-  if (Array.isArray(field.farms)) return field.farms;
-  if ((field.farms as JdFarmsEmbed).farms) return (field.farms as JdFarmsEmbed).farms!;
-  return [];
-}
+import { optionsResponse, jsonResponse, errorResponse } from "../_shared/cors.ts";
+import { getAuthenticatedUser, isResponse } from "../_shared/auth.ts";
+import {
+  callJohnDeereApi,
+  callJohnDeereUrl,
+  getValidToken,
+  getUserConnection,
+  JOHN_DEERE_API_BASE,
+  Connection,
+} from "../_shared/john-deere.ts";
+import {
+  convertBoundaryToGeoJSON,
+  extractClients,
+  extractFarms,
+  JdLink,
+  JdBoundary,
+  JdBoundaryPoint,
+  JdRing,
+  JdField,
+} from "../_shared/boundaries.ts";
 
 async function fetchAllFieldsPaginated(accessToken: string, orgId: string): Promise<JdField[]> {
   const allFields: JdField[] = [];
@@ -139,83 +40,22 @@ async function fetchAllFieldsPaginated(accessToken: string, orgId: string): Prom
   return allFields;
 }
 
-function convertBoundaryToGeoJSON(boundary: JdBoundary): { type: "MultiPolygon"; coordinates: number[][][][] } | null {
-  if (!boundary.multipolygons || boundary.multipolygons.length === 0) return null;
-
-  const polygons: number[][][][] = [];
-
-  for (const polygon of boundary.multipolygons) {
-    const rings: number[][][] = [];
-    const exteriorRings = (polygon.rings || []).filter((r: JdRing) => r.type === "exterior");
-    const interiorRings = (polygon.rings || []).filter((r: JdRing) => r.type === "interior");
-
-    for (const ring of exteriorRings) {
-      const coords = ring.points.map((p: JdBoundaryPoint) => [p.lon, p.lat]);
-      if (coords.length > 0 && (coords[0][0] !== coords[coords.length - 1][0] || coords[0][1] !== coords[coords.length - 1][1])) {
-        coords.push([...coords[0]]);
-      }
-      const polyRings: number[][][] = [coords];
-      for (const hole of interiorRings) {
-        const holeCoords = hole.points.map((p: JdBoundaryPoint) => [p.lon, p.lat]);
-        if (holeCoords.length > 0 && (holeCoords[0][0] !== holeCoords[holeCoords.length - 1][0] || holeCoords[0][1] !== holeCoords[holeCoords.length - 1][1])) {
-          holeCoords.push([...holeCoords[0]]);
-        }
-        polyRings.push(holeCoords);
-      }
-      rings.push(...polyRings);
-    }
-
-    if (rings.length > 0) {
-      polygons.push(rings);
-    }
-  }
-
-  if (polygons.length === 0) return null;
-  return { type: "MultiPolygon", coordinates: polygons };
-}
-
 Deno.serve(async (req: Request) => {
   if (req.method === "OPTIONS") {
-    return new Response(null, { status: 200, headers: corsHeaders });
+    return optionsResponse();
   }
 
   try {
-    const authHeader = req.headers.get("Authorization");
-    if (!authHeader) {
-      return new Response(JSON.stringify({ error: "No authorization header" }), {
-        status: 401,
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      });
+    const authResult = await getAuthenticatedUser(req);
+    if (isResponse(authResult)) return authResult;
+    const { user, supabase } = authResult;
+
+    const connection = await getUserConnection(supabase, user.id);
+    if (!connection) {
+      return errorResponse("No John Deere connection found", 404);
     }
 
-    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
-    const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
-    const supabase = createClient(supabaseUrl, supabaseServiceKey);
-
-    const token = authHeader.replace("Bearer ", "");
-    const { data: { user }, error: userError } = await supabase.auth.getUser(token);
-
-    if (userError || !user) {
-      return new Response(JSON.stringify({ error: "Invalid user token" }), {
-        status: 401,
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      });
-    }
-
-    const { data: connection, error: connError } = await supabase
-      .from("john_deere_connections")
-      .select("*")
-      .eq("user_id", user.id)
-      .maybeSingle();
-
-    if (connError || !connection) {
-      return new Response(JSON.stringify({ error: "No John Deere connection found" }), {
-        status: 404,
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      });
-    }
-
-    const accessToken = await getValidToken(supabase, connection as Connection);
+    const accessToken = await getValidToken(supabase, connection);
     const url = new URL(req.url);
     const action = url.searchParams.get("action");
 
@@ -224,26 +64,18 @@ Deno.serve(async (req: Request) => {
 
       if (!response.ok) {
         const errorText = await response.text();
-        return new Response(JSON.stringify({ error: `John Deere API error: ${response.status}`, details: errorText }), {
-          status: response.status,
-          headers: { ...corsHeaders, "Content-Type": "application/json" },
-        });
+        return errorResponse(`John Deere API error: ${response.status}`, response.status, errorText);
       }
 
       const data = await response.json();
-      return new Response(JSON.stringify(data), {
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      });
+      return jsonResponse(data);
     }
 
     if (action === "select-organization") {
       const { orgId, orgName } = await req.json();
 
       if (!orgId) {
-        return new Response(JSON.stringify({ error: "Missing orgId" }), {
-          status: 400,
-          headers: { ...corsHeaders, "Content-Type": "application/json" },
-        });
+        return errorResponse("Missing orgId", 400);
       }
 
       await supabase
@@ -255,55 +87,39 @@ Deno.serve(async (req: Request) => {
         })
         .eq("user_id", user.id);
 
-      return new Response(JSON.stringify({ success: true }), {
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      });
+      return jsonResponse({ success: true });
     }
 
     if (action === "fields") {
       const orgId = connection.selected_org_id;
 
       if (!orgId) {
-        return new Response(JSON.stringify({ error: "No organization selected" }), {
-          status: 400,
-          headers: { ...corsHeaders, "Content-Type": "application/json" },
-        });
+        return errorResponse("No organization selected", 400);
       }
 
       const response = await callJohnDeereApi(accessToken, `/organizations/${orgId}/fields`);
 
       if (!response.ok) {
         const errorText = await response.text();
-        return new Response(JSON.stringify({ error: `John Deere API error: ${response.status}`, details: errorText }), {
-          status: response.status,
-          headers: { ...corsHeaders, "Content-Type": "application/json" },
-        });
+        return errorResponse(`John Deere API error: ${response.status}`, response.status, errorText);
       }
 
       const data = await response.json();
-      return new Response(JSON.stringify(data), {
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      });
+      return jsonResponse(data);
     }
 
     if (action === "harvest-operations") {
       const orgId = connection.selected_org_id;
 
       if (!orgId) {
-        return new Response(JSON.stringify({ error: "No organization selected" }), {
-          status: 400,
-          headers: { ...corsHeaders, "Content-Type": "application/json" },
-        });
+        return errorResponse("No organization selected", 400);
       }
 
       const fieldsResponse = await callJohnDeereApi(accessToken, `/organizations/${orgId}/fields`);
 
       if (!fieldsResponse.ok) {
         const errorText = await fieldsResponse.text();
-        return new Response(JSON.stringify({ error: `Failed to fetch fields: ${fieldsResponse.status}`, details: errorText }), {
-          status: fieldsResponse.status,
-          headers: { ...corsHeaders, "Content-Type": "application/json" },
-        });
+        return errorResponse(`Failed to fetch fields: ${fieldsResponse.status}`, fieldsResponse.status, errorText);
       }
 
       const fieldsData = await fieldsResponse.json();
@@ -330,19 +146,55 @@ Deno.serve(async (req: Request) => {
         }
       }
 
-      return new Response(JSON.stringify({ values: allOperations }), {
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      });
+      return jsonResponse({ values: allOperations });
+    }
+
+    if (action === "seeding-operations") {
+      const orgId = connection.selected_org_id;
+
+      if (!orgId) {
+        return errorResponse("No organization selected", 400);
+      }
+
+      const fieldsResponse = await callJohnDeereApi(accessToken, `/organizations/${orgId}/fields`);
+
+      if (!fieldsResponse.ok) {
+        const errorText = await fieldsResponse.text();
+        return errorResponse(`Failed to fetch fields: ${fieldsResponse.status}`, fieldsResponse.status, errorText);
+      }
+
+      const fieldsData = await fieldsResponse.json();
+      const fields = fieldsData.values || [];
+
+      const allOperations: { fieldId: string; fieldName: string; operations: unknown[] }[] = [];
+
+      for (const field of fields) {
+        const fieldId = field.id;
+        const fieldName = field.name || "Unknown Field";
+
+        const opsResponse = await callJohnDeereApi(
+          accessToken,
+          `/organizations/${orgId}/fields/${fieldId}/fieldOperations?fieldOperationType=SEEDING`
+        );
+
+        if (opsResponse.ok) {
+          const opsData = await opsResponse.json();
+          allOperations.push({
+            fieldId,
+            fieldName,
+            operations: opsData.values || [],
+          });
+        }
+      }
+
+      return jsonResponse({ values: allOperations });
     }
 
     if (action === "import-fields") {
       const orgId = connection.selected_org_id;
 
       if (!orgId) {
-        return new Response(JSON.stringify({ error: "No organization selected" }), {
-          status: 400,
-          headers: { ...corsHeaders, "Content-Type": "application/json" },
-        });
+        return errorResponse("No organization selected", 400);
       }
 
       const allFields = await fetchAllFieldsPaginated(accessToken, orgId);
@@ -447,12 +299,10 @@ Deno.serve(async (req: Request) => {
         .eq("user_id", user.id)
         .eq("org_id", orgId);
 
-      return new Response(JSON.stringify({
+      return jsonResponse({
         fields: storedFields || [],
         totalImported: allFields.length,
         withoutBoundaries,
-      }), {
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
       });
     }
 
@@ -460,10 +310,7 @@ Deno.serve(async (req: Request) => {
       const orgId = connection.selected_org_id;
 
       if (!orgId) {
-        return new Response(JSON.stringify({ error: "No organization selected" }), {
-          status: 400,
-          headers: { ...corsHeaders, "Content-Type": "application/json" },
-        });
+        return errorResponse("No organization selected", 400);
       }
 
       const { data: storedFields, error: fieldsError } = await supabase
@@ -473,26 +320,15 @@ Deno.serve(async (req: Request) => {
         .eq("org_id", orgId);
 
       if (fieldsError) {
-        return new Response(JSON.stringify({ error: fieldsError.message }), {
-          status: 500,
-          headers: { ...corsHeaders, "Content-Type": "application/json" },
-        });
+        return errorResponse(fieldsError.message, 500);
       }
 
-      return new Response(JSON.stringify({ fields: storedFields || [] }), {
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      });
+      return jsonResponse({ fields: storedFields || [] });
     }
 
-    return new Response(JSON.stringify({ error: "Unknown action" }), {
-      status: 400,
-      headers: { ...corsHeaders, "Content-Type": "application/json" },
-    });
+    return errorResponse("Unknown action", 400);
   } catch (error) {
     console.error("Error:", error);
-    return new Response(JSON.stringify({ error: error.message }), {
-      status: 500,
-      headers: { ...corsHeaders, "Content-Type": "application/json" },
-    });
+    return errorResponse(error.message, 500);
   }
 });

--- a/supabase/functions/john-deere-auth/index.ts
+++ b/supabase/functions/john-deere-auth/index.ts
@@ -1,148 +1,31 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
-import { createClient } from "npm:@supabase/supabase-js@2";
-
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
-  "Access-Control-Allow-Headers": "Content-Type, Authorization, X-Client-Info, Apikey",
-};
-
-const JOHN_DEERE_TOKEN_URL = "https://signin.johndeere.com/oauth2/aus78tnlaysMraFhC1t7/v1/token";
-const JOHN_DEERE_CLIENT_ID = Deno.env.get("JOHN_DEERE_CLIENT_ID") || "";
-const JOHN_DEERE_CLIENT_SECRET = Deno.env.get("JOHN_DEERE_CLIENT_SECRET") || "";
-
-interface TokenResponse {
-  access_token: string;
-  refresh_token: string;
-  expires_in: number;
-  token_type: string;
-  scope: string;
-}
-
-async function exchangeCodeForTokens(code: string, redirectUri: string): Promise<TokenResponse> {
-  const params = new URLSearchParams({
-    grant_type: "authorization_code",
-    code,
-    redirect_uri: redirectUri,
-    client_id: JOHN_DEERE_CLIENT_ID,
-    client_secret: JOHN_DEERE_CLIENT_SECRET,
-  });
-
-  const response = await fetch(JOHN_DEERE_TOKEN_URL, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-      "Accept": "application/json",
-    },
-    body: params.toString(),
-  });
-
-  if (!response.ok) {
-    const errorText = await response.text();
-    throw new Error(`Token exchange failed: ${response.status} ${errorText}`);
-  }
-
-  return response.json();
-}
-
-async function refreshAccessToken(refreshToken: string): Promise<TokenResponse> {
-  const params = new URLSearchParams({
-    grant_type: "refresh_token",
-    refresh_token: refreshToken,
-    client_id: JOHN_DEERE_CLIENT_ID,
-    client_secret: JOHN_DEERE_CLIENT_SECRET,
-  });
-
-  const response = await fetch(JOHN_DEERE_TOKEN_URL, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-      "Accept": "application/json",
-    },
-    body: params.toString(),
-  });
-
-  if (!response.ok) {
-    const errorText = await response.text();
-    throw new Error(`Token refresh failed: ${response.status} ${errorText}`);
-  }
-
-  return response.json();
-}
+import { optionsResponse, jsonResponse, errorResponse } from "../_shared/cors.ts";
+import { getAuthenticatedUser, isResponse } from "../_shared/auth.ts";
+import { exchangeCodeForTokens, refreshAccessToken } from "../_shared/john-deere.ts";
 
 Deno.serve(async (req: Request) => {
   if (req.method === "OPTIONS") {
-    return new Response(null, { status: 200, headers: corsHeaders });
+    return optionsResponse();
   }
 
   try {
-    console.log("[john-deere-auth] Request received");
-    console.log("[john-deere-auth] Method:", req.method);
-    console.log("[john-deere-auth] URL:", req.url);
-
-    const authHeader = req.headers.get("Authorization");
-    console.log("[john-deere-auth] Auth header present:", !!authHeader);
-
-    if (!authHeader) {
-      console.error("[john-deere-auth] Missing authorization header");
-      return new Response(JSON.stringify({ error: "No authorization header" }), {
-        status: 401,
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      });
-    }
-
-    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
-    const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
-    console.log("[john-deere-auth] Supabase URL:", supabaseUrl);
-    console.log("[john-deere-auth] Service key present:", !!supabaseServiceKey);
-
-    const supabase = createClient(supabaseUrl, supabaseServiceKey);
-
-    const token = authHeader.replace("Bearer ", "");
-    console.log("[john-deere-auth] Token (first 20 chars):", token.substring(0, 20) + "...");
-
-    const { data: { user }, error: userError } = await supabase.auth.getUser(token);
-
-    console.log("[john-deere-auth] User lookup result - error:", userError);
-    console.log("[john-deere-auth] User lookup result - user ID:", user?.id);
-
-    if (userError || !user) {
-      console.error("[john-deere-auth] Invalid JWT - userError:", userError);
-      return new Response(JSON.stringify({
-        error: "Invalid user token",
-        details: userError?.message || "No user found",
-        code: 401
-      }), {
-        status: 401,
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      });
-    }
+    const authResult = await getAuthenticatedUser(req);
+    if (isResponse(authResult)) return authResult;
+    const { user, supabase } = authResult;
 
     const url = new URL(req.url);
     const action = url.searchParams.get("action");
 
     if (action === "exchange") {
-      console.log("[john-deere-auth] Action: exchange");
-
       const { code, redirectUri } = await req.json();
-      console.log("[john-deere-auth] Code present:", !!code);
-      console.log("[john-deere-auth] Redirect URI:", redirectUri);
 
       if (!code || !redirectUri) {
-        console.error("[john-deere-auth] Missing code or redirectUri");
-        return new Response(JSON.stringify({ error: "Missing code or redirectUri" }), {
-          status: 400,
-          headers: { ...corsHeaders, "Content-Type": "application/json" },
-        });
+        return errorResponse("Missing code or redirectUri", 400);
       }
 
-      console.log("[john-deere-auth] Calling John Deere token exchange...");
       const tokens = await exchangeCodeForTokens(code, redirectUri);
-      console.log("[john-deere-auth] Token exchange successful");
-
       const expiresAt = new Date(Date.now() + tokens.expires_in * 1000).toISOString();
 
-      console.log("[john-deere-auth] Saving to database for user:", user.id);
       const { error: upsertError } = await supabase
         .from("john_deere_connections")
         .upsert({
@@ -154,14 +37,10 @@ Deno.serve(async (req: Request) => {
         }, { onConflict: "user_id" });
 
       if (upsertError) {
-        console.error("[john-deere-auth] Database upsert error:", upsertError);
         throw new Error(`Failed to save tokens: ${upsertError.message}`);
       }
 
-      console.log("[john-deere-auth] Exchange complete");
-      return new Response(JSON.stringify({ success: true }), {
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      });
+      return jsonResponse({ success: true });
     }
 
     if (action === "refresh") {
@@ -172,10 +51,7 @@ Deno.serve(async (req: Request) => {
         .maybeSingle();
 
       if (connError || !connection) {
-        return new Response(JSON.stringify({ error: "No John Deere connection found" }), {
-          status: 404,
-          headers: { ...corsHeaders, "Content-Type": "application/json" },
-        });
+        return errorResponse("No John Deere connection found", 404);
       }
 
       const tokens = await refreshAccessToken(connection.refresh_token);
@@ -191,9 +67,7 @@ Deno.serve(async (req: Request) => {
         })
         .eq("user_id", user.id);
 
-      return new Response(JSON.stringify({ success: true }), {
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      });
+      return jsonResponse({ success: true });
     }
 
     if (action === "disconnect") {
@@ -202,20 +76,12 @@ Deno.serve(async (req: Request) => {
         .delete()
         .eq("user_id", user.id);
 
-      return new Response(JSON.stringify({ success: true }), {
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      });
+      return jsonResponse({ success: true });
     }
 
-    return new Response(JSON.stringify({ error: "Unknown action" }), {
-      status: 400,
-      headers: { ...corsHeaders, "Content-Type": "application/json" },
-    });
+    return errorResponse("Unknown action", 400);
   } catch (error) {
     console.error("Error:", error);
-    return new Response(JSON.stringify({ error: error.message }), {
-      status: 500,
-      headers: { ...corsHeaders, "Content-Type": "application/json" },
-    });
+    return errorResponse(error.message, 500);
   }
 });

--- a/supabase/functions/john-deere-irrigation/index.ts
+++ b/supabase/functions/john-deere-irrigation/index.ts
@@ -1,0 +1,229 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { optionsResponse, jsonResponse, errorResponse } from "../_shared/cors.ts";
+import { getAuthenticatedUser, isResponse } from "../_shared/auth.ts";
+import {
+  getValidToken,
+  getUserConnection,
+  JOHN_DEERE_API_BASE,
+} from "../_shared/john-deere.ts";
+import {
+  buildExteriorOnlyGeoJSON,
+  buildInteriorRingPolygons,
+  JdBoundary,
+} from "../_shared/boundaries.ts";
+import area from "npm:@turf/area@7";
+
+const SQM_TO_AC = 0.000247105;
+
+// --- Boundary-based irrigation analysis ---
+
+interface BoundaryAnalysisResult {
+  fieldId: string;
+  fieldName: string;
+  boundaryId: string;
+  irrigated: boolean;
+  totalArea: { value: number; unit: string };
+  workableArea: { value: number; unit: string };
+  irrigatedAcres: number;
+  drylandAcres: number;
+  exteriorGeoJSON: unknown;
+  interiorRingsGeoJSON: unknown[];
+}
+
+async function analyzeBoundary(
+  supabase: ReturnType<typeof import("npm:@supabase/supabase-js@2").createClient>,
+  userId: string,
+  fieldId: string,
+  fieldName: string,
+): Promise<BoundaryAnalysisResult> {
+  const { data: storedField, error: fieldError } = await supabase
+    .from("fields")
+    .select("raw_response")
+    .eq("user_id", userId)
+    .eq("jd_field_id", fieldId)
+    .maybeSingle();
+
+  if (fieldError || !storedField) {
+    throw new Error("Field not found in database");
+  }
+
+  const rawBoundaries: JdBoundary[] = storedField.raw_response?.boundaries || [];
+  const boundary = rawBoundaries.find((b: JdBoundary) => b.active) || rawBoundaries[0];
+
+  if (!boundary) {
+    throw new Error("No boundaries found for this field. Try re-importing fields.");
+  }
+
+  const totalAreaValue = boundary.area?.valueAsDouble ?? 0;
+  const totalAreaUnit = boundary.area?.unit ?? "ha";
+  const workableAreaValue = boundary.workableArea?.valueAsDouble ?? totalAreaValue;
+  const workableAreaUnit = boundary.workableArea?.unit ?? totalAreaUnit;
+
+  const exteriorGeoJSON = buildExteriorOnlyGeoJSON(boundary);
+  const interiorRings = buildInteriorRingPolygons(boundary);
+
+  let irrigatedAcres = 0;
+  let drylandAcres = 0;
+  const hasInteriorRings = interiorRings.length > 0;
+
+  if (exteriorGeoJSON) {
+    const totalSqm = area({ type: "Feature", geometry: exteriorGeoJSON, properties: {} });
+    const totalAc = totalSqm * SQM_TO_AC;
+
+    if (hasInteriorRings) {
+      let interiorSqm = 0;
+      for (const ring of interiorRings) {
+        interiorSqm += area({ type: "Feature", geometry: ring, properties: {} });
+      }
+      irrigatedAcres = interiorSqm * SQM_TO_AC;
+      drylandAcres = totalAc - irrigatedAcres;
+    } else {
+      if (boundary.irrigated === true) {
+        irrigatedAcres = totalAc;
+        drylandAcres = 0;
+      } else {
+        irrigatedAcres = 0;
+        drylandAcres = totalAc;
+      }
+    }
+  }
+
+  const isIrrigated = hasInteriorRings || boundary.irrigated === true;
+
+  return {
+    fieldId,
+    fieldName,
+    boundaryId: boundary.id,
+    irrigated: isIrrigated,
+    totalArea: { value: totalAreaValue, unit: totalAreaUnit },
+    workableArea: { value: workableAreaValue, unit: workableAreaUnit },
+    irrigatedAcres,
+    drylandAcres,
+    exteriorGeoJSON,
+    interiorRingsGeoJSON: interiorRings,
+  };
+}
+
+// --- Main handler ---
+
+Deno.serve(async (req: Request) => {
+  if (req.method === "OPTIONS") {
+    return optionsResponse();
+  }
+
+  try {
+    const authResult = await getAuthenticatedUser(req);
+    if (isResponse(authResult)) return authResult;
+    const { user, supabase } = authResult;
+
+    const connection = await getUserConnection(supabase, user.id);
+    if (!connection) {
+      return errorResponse("No John Deere connection found", 404);
+    }
+
+    const orgId = connection.selected_org_id;
+    if (!orgId) {
+      return errorResponse("No organization selected", 400);
+    }
+
+    const accessToken = await getValidToken(supabase, connection);
+    const url = new URL(req.url);
+    const action = url.searchParams.get("action");
+
+    if (action === "irrigation-analysis") {
+      const fieldId = url.searchParams.get("fieldId");
+      if (!fieldId) {
+        return errorResponse("Missing fieldId parameter", 400);
+      }
+
+      const { data: storedField } = await supabase
+        .from("fields")
+        .select("name")
+        .eq("user_id", user.id)
+        .eq("jd_field_id", fieldId)
+        .maybeSingle();
+
+      const fieldName = storedField?.name || "Unknown Field";
+      const result = await analyzeBoundary(supabase, user.id, fieldId, fieldName);
+      return jsonResponse(result);
+    }
+
+    // Polls JD for shapefile status. When ready, downloads zip and uploads
+    // to Supabase Storage so the client can fetch it without CORS issues.
+    if (action === "shapefile-status") {
+      const operationId = url.searchParams.get("operationId");
+      if (!operationId) {
+        return errorResponse("Missing operationId parameter", 400);
+      }
+
+      // Check if we already have this shapefile in storage
+      const storagePath = `${user.id}/${operationId}.zip`;
+      const { data: existing } = await supabase.storage
+        .from("shapefiles")
+        .list(user.id, { search: `${operationId}.zip` });
+
+      if (existing && existing.length > 0) {
+        return jsonResponse({ status: "ready", storagePath });
+      }
+
+      const shapefileUrl = `${JOHN_DEERE_API_BASE}/fieldOps/${operationId}?shapeType=Polygon&resolution=EachSensor`;
+
+      const response = await fetch(shapefileUrl, {
+        headers: {
+          "Authorization": `Bearer ${accessToken}`,
+          "Accept": "application/vnd.deere.axiom.v3+json",
+        },
+        redirect: "manual",
+      });
+
+      if (response.status === 307) {
+        const downloadUrl = response.headers.get("Location");
+        if (!downloadUrl) {
+          return errorResponse("Redirect with no Location header", 500);
+        }
+
+        // Download zip from JD's pre-signed URL
+        console.log(`[irrigation] Downloading shapefile from JD...`);
+        const zipResponse = await fetch(downloadUrl);
+        if (!zipResponse.ok) {
+          return errorResponse(`Failed to download shapefile: ${zipResponse.status}`, 502);
+        }
+
+        const zipBytes = new Uint8Array(await zipResponse.arrayBuffer());
+        console.log(`[irrigation] Downloaded ${(zipBytes.length / 1024).toFixed(0)} KB, uploading to storage...`);
+
+        // Upload to Supabase Storage
+        const { error: uploadError } = await supabase.storage
+          .from("shapefiles")
+          .upload(storagePath, zipBytes, {
+            contentType: "application/zip",
+            upsert: true,
+          });
+
+        if (uploadError) {
+          console.error("[irrigation] Storage upload error:", uploadError);
+          return errorResponse(`Failed to upload shapefile to storage: ${uploadError.message}`, 500);
+        }
+
+        console.log(`[irrigation] Shapefile uploaded to storage`);
+        return jsonResponse({ status: "ready", storagePath });
+      }
+
+      if (response.status === 202) {
+        return jsonResponse({ status: "processing" }, 202);
+      }
+
+      if (response.status === 406) {
+        return errorResponse("Shapefile cannot be generated for this operation", 406);
+      }
+
+      const text = await response.text();
+      return errorResponse(`Unexpected response from John Deere: ${response.status} ${text}`, response.status);
+    }
+
+    return errorResponse("Unknown action", 400);
+  } catch (error) {
+    console.error("[irrigation] Error:", error);
+    return errorResponse(error.message, 500);
+  }
+});

--- a/types/john-deere.ts
+++ b/types/john-deere.ts
@@ -33,8 +33,10 @@ export interface JohnDeereBoundary {
   id: string;
   name?: string;
   area?: JohnDeereMeasurement;
+  workableArea?: JohnDeereMeasurement;
   multipolygons: JohnDeerePolygon[];
   active: boolean;
+  irrigated?: boolean;
   links: JohnDeereLink[];
 }
 
@@ -113,4 +115,28 @@ export interface JohnDeereTokenResponse {
   expires_in: number;
   token_type: string;
   scope: string;
+}
+
+export interface IrrigationAnalysis {
+  fieldId: string;
+  fieldName: string;
+  boundaryId: string;
+  irrigated: boolean;
+  totalArea: { value: number; unit: string };
+  workableArea: { value: number; unit: string };
+  irrigatedAcres: number;
+  drylandAcres: number;
+  exteriorGeoJSON: GeoJSON.MultiPolygon | null;
+  interiorRingsGeoJSON: Array<GeoJSON.Polygon> | null;
+}
+
+export interface HarvestIrrigationAnalysis extends IrrigationAnalysis {
+  operationId: string;
+  harvestPolygons: GeoJSON.FeatureCollection | null;
+  irrigatedHarvestedAcres: number;
+  drylandHarvestedAcres: number;
+  irrigatedAvgYield: number | null;
+  drylandAvgYield: number | null;
+  irrigatedAvgMoisture: number | null;
+  drylandAvgMoisture: number | null;
 }


### PR DESCRIPTION
## Summary

- **Irrigation Analysis tab** on the dashboard that calculates irrigated vs dryland acres from JD field boundary data
- Interior boundary rings (pivot circles) are identified as the irrigated zone; dryland = total field minus irrigated
- **Shapefile-based analysis** for both harvest and seeding operations, displayed side-by-side
- Shapefiles are downloaded from JD, stored in **Supabase Storage** (avoiding CORS), then parsed and intersected with boundary zones **client-side** using turf.js + shpjs
- **Edge function refactor**: extracted shared modules (`_shared/cors.ts`, `auth.ts`, `john-deere.ts`, `boundaries.ts`) eliminating duplication across all three edge functions
- New `john-deere-irrigation` edge function for boundary analysis and shapefile status polling

### Screenshot

<img width="1374" height="816" alt="Irrigation Analysis Demo Image" src="https://github.com/user-attachments/assets/5a8d696c-f074-4bc8-88e1-75139eb880fd" />

> Dunk field: boundary analysis showing 132.9 irrigated ac / 16.3 dryland ac, with seeding and harvest shapefile analyses side-by-side

## Test plan

- [ ] Run `npm run typecheck` and `npm run build` — both pass
- [ ] Start local Supabase (`npx supabase start`) and create `shapefiles` storage bucket
- [ ] Sign in, connect JD account, select Owens Ag org, import fields
- [ ] Navigate to Irrigation tab → select Dunk field → Analyze Boundary
- [ ] Verify irrigated/dryland acre split with donut chart
- [ ] Select a seeding operation → Run Analysis → verify seeding rate breakdown by zone
- [ ] Select a harvest operation → Run Analysis → verify yield/moisture breakdown by zone
- [ ] Verify both analyses display side-by-side

🤖 Generated with [Claude Code](https://claude.com/claude-code)