### PR TITLE
Fetch and store irrigated boundaries separately

### DIFF
--- a/components/dashboard/irrigation-analysis.tsx
+++ b/components/dashboard/irrigation-analysis.tsx
@@ -85,13 +85,13 @@ function OperationSection({
       setProgressStatus(`Parsing shapefile (${(zipBuffer.byteLength / 1024 / 1024).toFixed(1)} MB)...`);
       const geojson = await processShapefile(zipBuffer);
 
-      const interiorRings = (analysis.interiorRingsGeoJSON || []) as Array<{ type: 'Polygon'; coordinates: number[][][] }>;
+      const irrigatedBoundary = (analysis.irrigatedBoundaryGeoJSON || null) as { type: 'MultiPolygon'; coordinates: number[][][][] } | null;
       setProgressStatus(`Analyzing ${geojson.features.length.toLocaleString()} polygons...`);
 
       if (title.toLowerCase().includes('seeding') || title.toLowerCase().includes('planting')) {
-        setResult(classifySeedingPolygons(geojson, interiorRings, analysis.irrigated));
+        setResult(classifySeedingPolygons(geojson, irrigatedBoundary, analysis.irrigated));
       } else {
-        setResult(classifyHarvestPolygons(geojson, interiorRings, analysis.irrigated));
+        setResult(classifyHarvestPolygons(geojson, irrigatedBoundary, analysis.irrigated));
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Analysis failed');

--- a/components/map/field-side-panel.tsx
+++ b/components/map/field-side-panel.tsx
@@ -73,6 +73,12 @@ export function FieldSidePanel() {
                       {formatArea(field.boundary_area_value, field.boundary_area_unit, preferredUnit)}
                     </span>
                   )}
+                  {field.has_irrigated_boundary && field.irrigated_boundary_area_value && (
+                    <span className="flex items-center gap-1 text-sm font-mono-data text-cyan-400">
+                      <Droplets className="w-3.5 h-3.5" />
+                      {formatArea(field.irrigated_boundary_area_value, field.irrigated_boundary_area_unit, preferredUnit)} irrigated
+                    </span>
+                  )}
                 </div>
               </div>
               <button
@@ -95,6 +101,12 @@ export function FieldSidePanel() {
                 <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg bg-amber-500/10 border border-amber-500/20 text-xs text-amber-300">
                   <span className="w-1.5 h-1.5 rounded-full bg-amber-400" />
                   {field.farm_name}
+                </span>
+              )}
+              {field.has_irrigated_boundary && (
+                <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg bg-cyan-500/10 border border-cyan-500/20 text-xs text-cyan-300">
+                  <span className="w-1.5 h-1.5 rounded-full bg-cyan-400" />
+                  Irrigated
                 </span>
               )}
             </div>

--- a/components/map/full-map.tsx
+++ b/components/map/full-map.tsx
@@ -12,6 +12,9 @@ const MAPBOX_TOKEN = process.env.NEXT_PUBLIC_MAPBOX_TOKEN || '';
 const SOURCE_ID = 'fields-source';
 const FILL_LAYER_ID = 'fields-fill';
 const LINE_LAYER_ID = 'fields-line';
+const IRRIGATED_SOURCE_ID = 'irrigated-fields-source';
+const IRRIGATED_FILL_LAYER_ID = 'irrigated-fields-fill';
+const IRRIGATED_LINE_LAYER_ID = 'irrigated-fields-line';
 const OP_IMAGE_SOURCE = 'op-image-source';
 const OP_IMAGE_LAYER = 'op-image-layer';
 
@@ -66,9 +69,10 @@ export function FullMap() {
     if (!map || !mapReady) return;
 
     // Clean up existing layers
-    [LINE_LAYER_ID, FILL_LAYER_ID].forEach(id => {
+    [IRRIGATED_LINE_LAYER_ID, IRRIGATED_FILL_LAYER_ID, LINE_LAYER_ID, FILL_LAYER_ID].forEach(id => {
       if (map.getLayer(id)) map.removeLayer(id);
     });
+    if (map.getSource(IRRIGATED_SOURCE_ID)) map.removeSource(IRRIGATED_SOURCE_ID);
     if (map.getSource(SOURCE_ID)) map.removeSource(SOURCE_ID);
 
     const fieldsWithBoundaries = filteredFields.filter(f => f.boundary_geojson);
@@ -133,10 +137,69 @@ export function FullMap() {
       },
     });
 
+    // Irrigated boundary layers
+    const fieldsWithIrrigated = filteredFields.filter(f => f.irrigated_boundary_geojson);
+    if (fieldsWithIrrigated.length > 0) {
+      const irrigatedFeatures = fieldsWithIrrigated.map(field => ({
+        type: 'Feature' as const,
+        properties: {
+          name: field.name,
+          jd_field_id: field.jd_field_id,
+          is_selected: field.jd_field_id === selectedFieldId ? 'true' : 'false',
+        },
+        geometry: field.irrigated_boundary_geojson!,
+      }));
+
+      map.addSource(IRRIGATED_SOURCE_ID, {
+        type: 'geojson',
+        data: { type: 'FeatureCollection', features: irrigatedFeatures },
+      });
+
+      map.addLayer({
+        id: IRRIGATED_FILL_LAYER_ID,
+        type: 'fill',
+        source: IRRIGATED_SOURCE_ID,
+        paint: {
+          'fill-color': '#06b6d4',
+          'fill-opacity': [
+            'case',
+            ['==', ['get', 'is_selected'], 'true'], 0.3,
+            0.15,
+          ],
+        },
+      });
+
+      map.addLayer({
+        id: IRRIGATED_LINE_LAYER_ID,
+        type: 'line',
+        source: IRRIGATED_SOURCE_ID,
+        paint: {
+          'line-color': '#22d3ee',
+          'line-width': [
+            'case',
+            ['==', ['get', 'is_selected'], 'true'], 2.5,
+            1.5,
+          ],
+          'line-opacity': 0.9,
+          'line-dasharray': [4, 3],
+        },
+      });
+    }
+
     // Fit bounds
     const bounds = new mapboxgl.LngLatBounds();
     for (const field of fieldsWithBoundaries) {
       const geojson = field.boundary_geojson!;
+      for (const polygon of geojson.coordinates) {
+        for (const ring of polygon) {
+          for (const coord of ring) {
+            bounds.extend(coord as [number, number]);
+          }
+        }
+      }
+    }
+    for (const field of fieldsWithIrrigated) {
+      const geojson = field.irrigated_boundary_geojson!;
       for (const polygon of geojson.coordinates) {
         for (const ring of polygon) {
           for (const coord of ring) {

--- a/lib/shapefile-analysis.ts
+++ b/lib/shapefile-analysis.ts
@@ -39,11 +39,11 @@ export async function processShapefile(
 
 /**
  * Classify harvest polygons as irrigated or dryland based on whether
- * they intersect with interior ring polygons (which represent the pivot/irrigated area).
+ * they intersect with the irrigated boundary polygon.
  */
 export function classifyHarvestPolygons(
   harvestGeoJSON: FeatureCollection,
-  interiorRingsGeoJSON: Array<{ type: 'Polygon'; coordinates: number[][][] }>,
+  irrigatedBoundaryGeoJSON: { type: 'MultiPolygon'; coordinates: number[][][][] } | null,
   irrigated: boolean,
 ): HarvestZoneStats {
   if (!harvestGeoJSON?.features) {
@@ -69,9 +69,9 @@ export function classifyHarvestPolygons(
   const irrigatedMoistures: number[] = [];
   const drylandMoistures: number[] = [];
 
-  const interiorFeatures = interiorRingsGeoJSON.map(
-    (ring) => turf.feature(ring) as Feature<Polygon>,
-  );
+  const irrigatedFeature = irrigatedBoundaryGeoJSON
+    ? turf.feature(irrigatedBoundaryGeoJSON) as Feature<MultiPolygon>
+    : null;
 
   for (const feature of harvestGeoJSON.features) {
     if (!feature.geometry) continue;
@@ -86,16 +86,13 @@ export function classifyHarvestPolygons(
 
     let isIrrigatedPolygon = false;
 
-    if (interiorFeatures.length > 0) {
-      for (const interiorFeature of interiorFeatures) {
-        try {
-          if (turf.booleanIntersects(feature as Feature<Polygon | MultiPolygon>, interiorFeature)) {
-            isIrrigatedPolygon = true;
-            break;
-          }
-        } catch {
-          // Skip invalid geometries
+    if (irrigatedFeature) {
+      try {
+        if (turf.booleanIntersects(feature as Feature<Polygon | MultiPolygon>, irrigatedFeature)) {
+          isIrrigatedPolygon = true;
         }
+      } catch {
+        // Skip invalid geometries
       }
     } else if (irrigated) {
       isIrrigatedPolygon = true;
@@ -147,11 +144,11 @@ export interface SeedingZoneStats {
 
 /**
  * Classify seeding polygons as irrigated or dryland based on whether
- * they intersect with interior ring polygons (pivot/irrigated area).
+ * they intersect with the irrigated boundary polygon.
  */
 export function classifySeedingPolygons(
   seedingGeoJSON: FeatureCollection,
-  interiorRingsGeoJSON: Array<{ type: 'Polygon'; coordinates: number[][][] }>,
+  irrigatedBoundaryGeoJSON: { type: 'MultiPolygon'; coordinates: number[][][][] } | null,
   irrigated: boolean,
 ): SeedingZoneStats {
   if (!seedingGeoJSON?.features) {
@@ -173,9 +170,9 @@ export function classifySeedingPolygons(
   const irrigatedControlRates: number[] = [];
   const drylandControlRates: number[] = [];
 
-  const interiorFeatures = interiorRingsGeoJSON.map(
-    (ring) => turf.feature(ring) as Feature<Polygon>,
-  );
+  const irrigatedFeature = irrigatedBoundaryGeoJSON
+    ? turf.feature(irrigatedBoundaryGeoJSON) as Feature<MultiPolygon>
+    : null;
 
   for (const feature of seedingGeoJSON.features) {
     if (!feature.geometry) continue;
@@ -189,16 +186,13 @@ export function classifySeedingPolygons(
 
     let isIrrigatedPolygon = false;
 
-    if (interiorFeatures.length > 0) {
-      for (const interiorFeature of interiorFeatures) {
-        try {
-          if (turf.booleanIntersects(feature as Feature<Polygon | MultiPolygon>, interiorFeature)) {
-            isIrrigatedPolygon = true;
-            break;
-          }
-        } catch {
-          // Skip invalid geometries
+    if (irrigatedFeature) {
+      try {
+        if (turf.booleanIntersects(feature as Feature<Polygon | MultiPolygon>, irrigatedFeature)) {
+          isIrrigatedPolygon = true;
         }
+      } catch {
+        // Skip invalid geometries
       }
     } else if (irrigated) {
       isIrrigatedPolygon = true;

--- a/supabase/functions/john-deere-import/index.ts
+++ b/supabase/functions/john-deere-import/index.ts
@@ -39,6 +39,26 @@ async function fetchAllFieldsPaginated(accessToken: string, orgId: string): Prom
   return allFields;
 }
 
+async function fetchIrrigatedBoundary(
+  accessToken: string,
+  orgId: string,
+  fieldId: string,
+): Promise<JdBoundary | null> {
+  try {
+    const response = await callJohnDeereApi(
+      accessToken,
+      `/organizations/${orgId}/fields/${fieldId}/boundaries?recordFilter=all`,
+    );
+    if (!response.ok) return null;
+
+    const data = await response.json();
+    const boundaries: JdBoundary[] = data.values || [];
+    return boundaries.find((b) => b.irrigated === true) || null;
+  } catch (_) {
+    return null;
+  }
+}
+
 async function importFields(
   supabase: SupabaseClient,
   accessToken: string,
@@ -70,6 +90,21 @@ async function importFields(
 
     if (!boundaryGeojson) {
       withoutBoundaries++;
+    }
+
+    let irrigatedBoundaryGeojson = null;
+    let irrigatedBoundaryAreaValue = null;
+    let irrigatedBoundaryAreaUnit = null;
+    let hasIrrigatedBoundary = false;
+
+    const irrigatedBoundary = await fetchIrrigatedBoundary(accessToken, orgId, field.id);
+    if (irrigatedBoundary) {
+      irrigatedBoundaryGeojson = convertBoundaryToGeoJSON(irrigatedBoundary);
+      if (irrigatedBoundary.area) {
+        irrigatedBoundaryAreaValue = irrigatedBoundary.area.valueAsDouble;
+        irrigatedBoundaryAreaUnit = irrigatedBoundary.area.unit;
+      }
+      hasIrrigatedBoundary = !!irrigatedBoundaryGeojson;
     }
 
     let clientName: string | null = null;
@@ -131,6 +166,10 @@ async function importFields(
         boundary_area_value: boundaryAreaValue,
         boundary_area_unit: boundaryAreaUnit,
         active_boundary: activeBoundary,
+        irrigated_boundary_geojson: irrigatedBoundaryGeojson,
+        irrigated_boundary_area_value: irrigatedBoundaryAreaValue,
+        irrigated_boundary_area_unit: irrigatedBoundaryAreaUnit,
+        has_irrigated_boundary: hasIrrigatedBoundary,
         client_name: clientName,
         client_id: clientId,
         farm_name: farmName,

--- a/supabase/functions/john-deere-irrigation/index.ts
+++ b/supabase/functions/john-deere-irrigation/index.ts
@@ -8,7 +8,6 @@ import {
 } from "../_shared/john-deere.ts";
 import {
   buildExteriorOnlyGeoJSON,
-  buildInteriorRingPolygons,
   JdBoundary,
 } from "../_shared/boundaries.ts";
 import area from "npm:@turf/area@7";
@@ -27,7 +26,7 @@ interface BoundaryAnalysisResult {
   irrigatedAcres: number;
   drylandAcres: number;
   exteriorGeoJSON: unknown;
-  interiorRingsGeoJSON: unknown[];
+  irrigatedBoundaryGeoJSON: unknown;
 }
 
 async function analyzeBoundary(
@@ -38,7 +37,7 @@ async function analyzeBoundary(
 ): Promise<BoundaryAnalysisResult> {
   const { data: storedField, error: fieldError } = await supabase
     .from("fields")
-    .select("raw_response")
+    .select("raw_response, irrigated_boundary_geojson, has_irrigated_boundary")
     .eq("user_id", userId)
     .eq("jd_field_id", fieldId)
     .maybeSingle();
@@ -60,35 +59,29 @@ async function analyzeBoundary(
   const workableAreaUnit = boundary.workableArea?.unit ?? totalAreaUnit;
 
   const exteriorGeoJSON = buildExteriorOnlyGeoJSON(boundary);
-  const interiorRings = buildInteriorRingPolygons(boundary);
+  const irrigatedBoundaryGeoJSON = storedField.irrigated_boundary_geojson || null;
 
   let irrigatedAcres = 0;
   let drylandAcres = 0;
-  const hasInteriorRings = interiorRings.length > 0;
 
   if (exteriorGeoJSON) {
     const totalSqm = area({ type: "Feature", geometry: exteriorGeoJSON, properties: {} });
     const totalAc = totalSqm * SQM_TO_AC;
 
-    if (hasInteriorRings) {
-      let interiorSqm = 0;
-      for (const ring of interiorRings) {
-        interiorSqm += area({ type: "Feature", geometry: ring, properties: {} });
-      }
-      irrigatedAcres = interiorSqm * SQM_TO_AC;
+    if (storedField.has_irrigated_boundary && irrigatedBoundaryGeoJSON) {
+      const irrigatedSqm = area({ type: "Feature", geometry: irrigatedBoundaryGeoJSON, properties: {} });
+      irrigatedAcres = irrigatedSqm * SQM_TO_AC;
       drylandAcres = totalAc - irrigatedAcres;
+    } else if (boundary.irrigated === true) {
+      irrigatedAcres = totalAc;
+      drylandAcres = 0;
     } else {
-      if (boundary.irrigated === true) {
-        irrigatedAcres = totalAc;
-        drylandAcres = 0;
-      } else {
-        irrigatedAcres = 0;
-        drylandAcres = totalAc;
-      }
+      irrigatedAcres = 0;
+      drylandAcres = totalAc;
     }
   }
 
-  const isIrrigated = hasInteriorRings || boundary.irrigated === true;
+  const isIrrigated = storedField.has_irrigated_boundary || boundary.irrigated === true;
 
   return {
     fieldId,
@@ -100,7 +93,7 @@ async function analyzeBoundary(
     irrigatedAcres,
     drylandAcres,
     exteriorGeoJSON,
-    interiorRingsGeoJSON: interiorRings,
+    irrigatedBoundaryGeoJSON,
   };
 }
 

--- a/supabase/migrations/20260328000000_add_irrigated_boundary_to_fields.sql
+++ b/supabase/migrations/20260328000000_add_irrigated_boundary_to_fields.sql
@@ -1,0 +1,44 @@
+/*
+  # Add irrigated boundary columns to fields table
+
+  The John Deere API now exposes irrigated boundaries as separate boundary objects
+  (with irrigated: true) rather than as interior rings within the active boundary.
+  These columns store the irrigated boundary separately from the active boundary.
+
+  New Columns:
+    - `irrigated_boundary_geojson` (jsonb) - GeoJSON MultiPolygon of the irrigated boundary
+    - `irrigated_boundary_area_value` (double precision) - area of the irrigated boundary
+    - `irrigated_boundary_area_unit` (text) - unit (e.g., "ha", "ac")
+    - `has_irrigated_boundary` (boolean) - quick filter flag
+*/
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'fields' AND column_name = 'irrigated_boundary_geojson'
+  ) THEN
+    ALTER TABLE fields ADD COLUMN irrigated_boundary_geojson jsonb;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'fields' AND column_name = 'irrigated_boundary_area_value'
+  ) THEN
+    ALTER TABLE fields ADD COLUMN irrigated_boundary_area_value double precision;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'fields' AND column_name = 'irrigated_boundary_area_unit'
+  ) THEN
+    ALTER TABLE fields ADD COLUMN irrigated_boundary_area_unit text;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'fields' AND column_name = 'has_irrigated_boundary'
+  ) THEN
+    ALTER TABLE fields ADD COLUMN has_irrigated_boundary boolean DEFAULT false;
+  END IF;
+END $$;

--- a/types/john-deere.ts
+++ b/types/john-deere.ts
@@ -94,6 +94,10 @@ export interface StoredField {
   boundary_area_value: number | null;
   boundary_area_unit: string | null;
   active_boundary: boolean;
+  irrigated_boundary_geojson: GeoJSON.MultiPolygon | null;
+  irrigated_boundary_area_value: number | null;
+  irrigated_boundary_area_unit: string | null;
+  has_irrigated_boundary: boolean;
   client_name: string | null;
   client_id: string | null;
   farm_name: string | null;
@@ -157,7 +161,7 @@ export interface IrrigationAnalysis {
   irrigatedAcres: number;
   drylandAcres: number;
   exteriorGeoJSON: GeoJSON.MultiPolygon | null;
-  interiorRingsGeoJSON: Array<GeoJSON.Polygon> | null;
+  irrigatedBoundaryGeoJSON: GeoJSON.MultiPolygon | null;
 }
 
 export interface HarvestIrrigationAnalysis extends IrrigationAnalysis {


### PR DESCRIPTION
## Summary
- The JD Operations Center API now exposes irrigated boundaries as separate boundary objects (`irrigated: true`) rather than as interior rings within the active boundary
- During field import, calls the boundaries endpoint with `recordFilter=all` for each field to find and store the irrigated boundary in new `fields` table columns
- Displays irrigated boundaries on the map as a cyan dashed outline, distinct from the emerald active boundary
- Updates irrigation analysis and shapefile classification to use the separate irrigated boundary instead of interior ring logic

## Test plan
- [ ] Re-import fields for an org with irrigated boundaries (e.g., Dunk field)
- [ ] Verify `irrigated_boundary_geojson` is populated in the DB
- [ ] Confirm cyan dashed irrigated boundary appears on the map
- [ ] Check field side panel shows irrigated area and badge
- [ ] Run irrigation analysis and verify irrigated/dryland acres are correct
- [ ] Verify fields without irrigated boundaries still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)